### PR TITLE
28 formato caf caffeine asset format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(SDL3 CONFIG QUIET)
 add_library(Caffeine
     src/core/Timer.cpp
     src/core/GameLoop.cpp
+    src/core/io/BlobLoader.cpp
+    src/core/io/CafWriter.cpp
     src/input/InputManager.cpp
     src/debug/LogSystem.cpp
     src/debug/Profiler.cpp

--- a/src/Caffeine.hpp
+++ b/src/Caffeine.hpp
@@ -5,6 +5,11 @@
 #include "core/Compiler.hpp"
 #include "core/Assertions.hpp"
 
+#include "core/io/CafTypes.hpp"
+#include "core/io/Crc32.hpp"
+#include "core/io/BlobLoader.hpp"
+#include "core/io/CafWriter.hpp"
+
 #include "memory/Allocator.hpp"
 #include "memory/LinearAllocator.hpp"
 #include "memory/PoolAllocator.hpp"

--- a/src/core/io/BlobLoader.cpp
+++ b/src/core/io/BlobLoader.cpp
@@ -28,25 +28,7 @@ BlobLoader::LoadResult BlobLoader::load(const char* path, IAllocator* allocator)
         return result;
     }
 
-    CafHeader headerPeek{};
-    if (std::fread(&headerPeek, sizeof(CafHeader), 1, file) != 1) {
-        std::fclose(file);
-        return result;
-    }
-    std::rewind(file);
-
-    if (headerPeek.magic != CafHeader::kMagic) {
-        std::fclose(file);
-        return result;
-    }
-
-    const u64 expectedFileSize = headerPeek.totalFileSize();
-    if (fileSize != expectedFileSize) {
-        std::fclose(file);
-        return result;
-    }
-
-    void* buf = allocator->alloc(fileSize, headerPeek.payloadAlignment());
+    void* buf = allocator->alloc(fileSize, 16);
     if (!buf) {
         std::fclose(file);
         return result;
@@ -61,9 +43,24 @@ BlobLoader::LoadResult BlobLoader::load(const char* path, IAllocator* allocator)
     const auto* header = static_cast<const CafHeader*>(buf);
     const auto* bytes  = static_cast<const u8*>(buf);
 
+    if (header->magic != CafHeader::kMagic)
+        return result;
+
+    if (header->versionMajor != CafHeader::kVersionMajor)
+        return result;
+
+    if (fileSize != header->totalFileSize())
+        return result;
+
     const u8* payloadPtr =
         bytes + CafHeader::kHeaderSize + header->metadataSize;
+
     if (!verifyCRC32(payloadPtr, header->dataSize, header->crc32))
+        return result;
+
+    const u32 footerCrc  = *reinterpret_cast<const u32*>(bytes + fileSize - CafHeader::kFooterSize);
+    const u32 computedCrc = Caffeine::IO::crc32(buf, fileSize - CafHeader::kFooterSize);
+    if (footerCrc != computedCrc)
         return result;
 
     result.header   = header;

--- a/src/core/io/BlobLoader.cpp
+++ b/src/core/io/BlobLoader.cpp
@@ -1,0 +1,95 @@
+#include "core/io/BlobLoader.hpp"
+#include "core/io/Crc32.hpp"
+#include "core/Assertions.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+namespace Caffeine::IO {
+
+BlobLoader::LoadResult BlobLoader::load(const char* path, IAllocator* allocator) {
+    CF_ASSERT(path != nullptr,      "BlobLoader::load: path is null");
+    CF_ASSERT(allocator != nullptr, "BlobLoader::load: allocator is null");
+
+    LoadResult result{};
+
+    std::FILE* file = std::fopen(path, "rb");
+    if (!file) return result;
+
+    std::fseek(file, 0, SEEK_END);
+    const u64 fileSize = static_cast<u64>(std::ftell(file));
+    std::rewind(file);
+
+    constexpr u64 kMinFileSize =
+        CafHeader::kHeaderSize + CafHeader::kFooterSize;
+
+    if (fileSize < kMinFileSize) {
+        std::fclose(file);
+        return result;
+    }
+
+    CafHeader headerPeek{};
+    if (std::fread(&headerPeek, sizeof(CafHeader), 1, file) != 1) {
+        std::fclose(file);
+        return result;
+    }
+    std::rewind(file);
+
+    if (headerPeek.magic != CafHeader::kMagic) {
+        std::fclose(file);
+        return result;
+    }
+
+    const u64 expectedFileSize = headerPeek.totalFileSize();
+    if (fileSize != expectedFileSize) {
+        std::fclose(file);
+        return result;
+    }
+
+    void* buf = allocator->alloc(fileSize, headerPeek.payloadAlignment());
+    if (!buf) {
+        std::fclose(file);
+        return result;
+    }
+
+    if (std::fread(buf, 1, fileSize, file) != fileSize) {
+        std::fclose(file);
+        return result;
+    }
+    std::fclose(file);
+
+    const auto* header = static_cast<const CafHeader*>(buf);
+    const auto* bytes  = static_cast<const u8*>(buf);
+
+    const u8* payloadPtr =
+        bytes + CafHeader::kHeaderSize + header->metadataSize;
+    if (!verifyCRC32(payloadPtr, header->dataSize, header->crc32))
+        return result;
+
+    result.header   = header;
+    result.metadata = bytes + CafHeader::kHeaderSize;
+    result.payload  = payloadPtr;
+    result.valid    = true;
+    return result;
+}
+
+bool BlobLoader::validateHeader(const char* path) {
+    CF_ASSERT(path != nullptr, "BlobLoader::validateHeader: path is null");
+
+    std::FILE* file = std::fopen(path, "rb");
+    if (!file) return false;
+
+    CafHeader header{};
+    const bool ok = (std::fread(&header, sizeof(CafHeader), 1, file) == 1);
+    std::fclose(file);
+
+    return ok
+        && header.magic        == CafHeader::kMagic
+        && header.versionMajor == CafHeader::kVersionMajor;
+}
+
+bool BlobLoader::verifyCRC32(const void* data, u64 size, u32 expected) {
+    return Caffeine::IO::crc32(data, size) == expected;
+}
+
+} // namespace Caffeine::IO

--- a/src/core/io/BlobLoader.hpp
+++ b/src/core/io/BlobLoader.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "core/io/CafTypes.hpp"
+#include "memory/Allocator.hpp"
+
+namespace Caffeine::IO {
+
+class BlobLoader {
+public:
+    struct LoadResult {
+        const CafHeader* header   = nullptr;
+        const void*      metadata = nullptr;
+        const void*      payload  = nullptr;
+        bool             valid    = false;
+    };
+
+    static LoadResult load(const char* path, IAllocator* allocator);
+    static bool       validateHeader(const char* path);
+
+private:
+    static bool verifyCRC32(const void* data, u64 size, u32 expected);
+};
+
+} // namespace Caffeine::IO

--- a/src/core/io/CafTypes.hpp
+++ b/src/core/io/CafTypes.hpp
@@ -1,0 +1,166 @@
+// ============================================================================
+// @file    CafTypes.hpp
+// @brief   Caffeine Asset Format (.caf) — type definitions
+//
+//  Philosophy: Zero-parsing, Zero-copy.
+//  The file on disk is a direct mirror of RAM/VRAM layout.
+//  No deserialization: file is read as a raw byte block.
+//
+//  File layout:
+//    [0 ..  31]  CafHeader        (32 bytes, SIMD-aligned)
+//    [32 .. 32+N-1]  Metadata block   (N = header.metadataSize)
+//    [32+N .. 32+N+M-1]  Payload      (M = header.dataSize)
+//    [32+N+M .. 32+N+M+3]  CRC32 footer (whole-file integrity)
+//
+//  Endianness: Little-endian (x86/x64 native, zero byte-swap)
+//  Magic:      0xCAFECAFE
+// ============================================================================
+#pragma once
+
+#include "core/Types.hpp"
+#include <functional>
+
+namespace Caffeine {
+
+// ============================================================================
+// @brief  Asset type discriminator stored in every .caf header.
+// ============================================================================
+enum class AssetType : u16 {
+    Unknown   = 0,
+    Texture,       // RGBA8, BC7, ASTC  → SDL_GPUTexture
+    Audio,         // PCM, ADPCM        → SDL_AudioStream
+    Mesh,          // Vertex/Index Buffers (Fase 5)
+    Prefab,        // ECS Entity Template (binary)
+    Scene,         // World State (Fase 4)
+    Shader,        // SPIR-V / bytecode
+    Animation,     // AnimationClip frames
+    Font           // Bitmap/SDF font atlas
+};
+
+// ============================================================================
+// @brief  Header flags bitmask (stored in CafHeader::flags).
+// ============================================================================
+enum CafFlags : u16 {
+    CAF_FLAG_NONE        = 0x0000,
+    CAF_FLAG_COMPRESSED  = 0x0001,  // payload is compressed
+    CAF_FLAG_ENCRYPTED   = 0x0002,  // payload is encrypted
+    CAF_FLAG_SRGB        = 0x0004,  // texture: sRGB colour space
+    CAF_FLAG_MIPCHAIN    = 0x0008,  // texture: mip-chain present
+    CAF_FLAG_STREAMED    = 0x0010,  // asset should be streamed
+};
+
+// ============================================================================
+// @brief  32-byte header for every .caf file.
+//
+//  Layout (natural alignment, little-endian):
+//    offset  0  u32  magic          4 bytes
+//    offset  4  u16  versionMajor   2 bytes
+//    offset  6  u16  versionMinor   2 bytes
+//    offset  8  u16  type           2 bytes  (AssetType)
+//    offset 10  u16  flags          2 bytes  (CafFlags)
+//    offset 12  u32  crc32          4 bytes  (CRC32 of payload only)
+//    offset 16  u64  metadataSize   8 bytes
+//    offset 24  u64  dataSize       8 bytes
+//                                  --------
+//                                  32 bytes  ✓
+// ============================================================================
+struct CafHeader {
+    u32       magic;         // 0xCAFECAFE — file identity marker
+    u16       versionMajor;  // breaking format changes
+    u16       versionMinor;  // backwards-compatible changes
+    AssetType type;          // asset kind
+    u16       flags;         // CafFlags bitmask
+    u32       crc32;         // CRC32 of the raw payload bytes
+    u64       metadataSize;  // size of the metadata block in bytes
+    u64       dataSize;      // size of the binary payload in bytes
+
+    // -------------------------------------------------------------------------
+    // Compile-time constants
+    // -------------------------------------------------------------------------
+    static constexpr u32  kMagic          = 0xCAFECAFEu;
+    static constexpr u16  kVersionMajor   = 1;
+    static constexpr u16  kVersionMinor   = 0;
+    static constexpr u32  kHeaderSize     = 32;
+    static constexpr u32  kFooterSize     = 4;   // trailing whole-file CRC32
+
+    // -------------------------------------------------------------------------
+    // @brief  Required payload alignment for this asset type.
+    //         Mesh/Shader: 32 bytes (SIMD + GPU bus)
+    //         All others:  16 bytes (SIMD)
+    // -------------------------------------------------------------------------
+    [[nodiscard]] constexpr u32 payloadAlignment() const noexcept {
+        return (type == AssetType::Mesh || type == AssetType::Shader) ? 32u : 16u;
+    }
+
+    // -------------------------------------------------------------------------
+    // @brief  Total byte size of the full .caf file on disk.
+    // -------------------------------------------------------------------------
+    [[nodiscard]] constexpr u64 totalFileSize() const noexcept {
+        return kHeaderSize + metadataSize + dataSize + kFooterSize;
+    }
+};
+
+static_assert(sizeof(CafHeader)  == 32, "CafHeader must be exactly 32 bytes");
+static_assert(alignof(CafHeader) ==  8, "CafHeader must be 8-byte aligned");
+
+// ============================================================================
+// Metadata structs — one per asset type.
+// These are written immediately after the CafHeader in the metadata block.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// @brief  Texture metadata (24 bytes, offset 32 in file).
+// ----------------------------------------------------------------------------
+struct TextureMetadata {
+    u32 width;       // pixels
+    u32 height;      // pixels
+    u32 format;      // SDL_GPUTextureFormat (or 0 for RGBA8)
+    u32 mipLevels;   // 1 = no mips
+    u64 reserved;    // future use, must be zero
+};
+static_assert(sizeof(TextureMetadata) == 24, "TextureMetadata must be 24 bytes");
+
+// ----------------------------------------------------------------------------
+// @brief  Audio metadata (16 bytes, offset 32 in file).
+// ----------------------------------------------------------------------------
+struct AudioMetadata {
+    u32 sampleRate;    // e.g. 44100, 48000
+    u16 channels;      // 1 = mono, 2 = stereo
+    u16 bitsPerSample; // 8, 16, or 32
+    u32 sampleCount;   // total sample frames
+    u32 reserved;      // future use, must be zero
+};
+static_assert(sizeof(AudioMetadata) == 16, "AudioMetadata must be 16 bytes");
+
+// ----------------------------------------------------------------------------
+// @brief  Scene / Prefab metadata header (20 bytes, offset 32 in file).
+// ----------------------------------------------------------------------------
+struct SceneMetadata {
+    u32 entityCount;          // total entities in the scene
+    u32 archetypeCount;       // number of distinct archetypes
+    u32 stringTableOffset;    // byte offset from start of metadata block
+    u32 assetRefTableOffset;  // byte offset from start of metadata block
+    u32 reserved;             // future use, must be zero
+};
+static_assert(sizeof(SceneMetadata) == 20, "SceneMetadata must be 20 bytes");
+
+// ----------------------------------------------------------------------------
+// @brief  Per-archetype descriptor (12 bytes, follows SceneMetadata).
+// ----------------------------------------------------------------------------
+struct ArchetypeDesc {
+    u32 componentMask;  // bitmask of component types present
+    u32 entityCount;    // entities belonging to this archetype
+    u32 dataOffset;     // byte offset into the payload where data begins
+};
+static_assert(sizeof(ArchetypeDesc) == 12, "ArchetypeDesc must be 12 bytes");
+
+// ----------------------------------------------------------------------------
+// @brief  Shader metadata (8 bytes, offset 32 in file).
+// ----------------------------------------------------------------------------
+struct ShaderMetadata {
+    u32 stage;    // shader stage (0=vertex, 1=fragment, 2=compute)
+    u32 reserved; // future use, must be zero
+};
+static_assert(sizeof(ShaderMetadata) == 8, "ShaderMetadata must be 8 bytes");
+
+} // namespace Caffeine

--- a/src/core/io/CafTypes.hpp
+++ b/src/core/io/CafTypes.hpp
@@ -19,6 +19,7 @@
 
 #include "core/Types.hpp"
 #include <functional>
+#include <bit>
 
 namespace Caffeine {
 
@@ -102,6 +103,7 @@ struct CafHeader {
 
 static_assert(sizeof(CafHeader)  == 32, "CafHeader must be exactly 32 bytes");
 static_assert(alignof(CafHeader) ==  8, "CafHeader must be 8-byte aligned");
+static_assert(std::endian::native == std::endian::little, ".caf requires a little-endian platform");
 
 // ============================================================================
 // Metadata structs — one per asset type.

--- a/src/core/io/CafWriter.cpp
+++ b/src/core/io/CafWriter.cpp
@@ -1,0 +1,71 @@
+#include "core/io/CafWriter.hpp"
+#include "core/io/Crc32.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+namespace Caffeine::IO {
+
+CafWriter::WriteResult CafWriter::write(
+    const char* path,
+    AssetType   type,
+    u16         flags,
+    const void* metadata,
+    u64         metadataSize,
+    const void* payload,
+    u64         payloadSize)
+{
+    WriteResult result{};
+
+    std::FILE* file = std::fopen(path, "wb");
+    if (!file) return result;
+
+    const u32 payloadCrc = crc32(payload, payloadSize);
+
+    CafHeader header{};
+    header.magic        = CafHeader::kMagic;
+    header.versionMajor = CafHeader::kVersionMajor;
+    header.versionMinor = CafHeader::kVersionMinor;
+    header.type         = type;
+    header.flags        = flags;
+    header.crc32        = payloadCrc;
+    header.metadataSize = metadataSize;
+    header.dataSize     = payloadSize;
+
+    if (std::fwrite(&header, sizeof(CafHeader), 1, file) != 1) {
+        std::fclose(file);
+        return result;
+    }
+
+    if (metadataSize > 0 && metadata != nullptr) {
+        if (std::fwrite(metadata, 1, metadataSize, file) != metadataSize) {
+            std::fclose(file);
+            return result;
+        }
+    }
+
+    if (payloadSize > 0 && payload != nullptr) {
+        if (std::fwrite(payload, 1, payloadSize, file) != payloadSize) {
+            std::fclose(file);
+            return result;
+        }
+    }
+
+    u32 wholeCrc = crc32(&header, sizeof(CafHeader));
+    if (metadataSize > 0 && metadata != nullptr)
+        wholeCrc = crc32Continue(wholeCrc, metadata, metadataSize);
+    if (payloadSize > 0 && payload != nullptr)
+        wholeCrc = crc32Continue(wholeCrc, payload, payloadSize);
+
+    if (std::fwrite(&wholeCrc, sizeof(u32), 1, file) != 1) {
+        std::fclose(file);
+        return result;
+    }
+
+    result.bytesWritten = header.totalFileSize();
+    result.success      = true;
+    std::fclose(file);
+    return result;
+}
+
+} // namespace Caffeine::IO

--- a/src/core/io/CafWriter.hpp
+++ b/src/core/io/CafWriter.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "core/io/CafTypes.hpp"
+
+namespace Caffeine::IO {
+
+class CafWriter {
+public:
+    struct WriteResult {
+        bool    success   = false;
+        u64     bytesWritten = 0;
+    };
+
+    static WriteResult write(
+        const char*    path,
+        AssetType      type,
+        u16            flags,
+        const void*    metadata,
+        u64            metadataSize,
+        const void*    payload,
+        u64            payloadSize);
+};
+
+} // namespace Caffeine::IO

--- a/src/core/io/Crc32.hpp
+++ b/src/core/io/Crc32.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "core/Types.hpp"
+
+namespace Caffeine::IO {
+
+// CRC32 using the standard IEEE 802.3 polynomial (0xEDB88320, reflected).
+// Self-contained — no external dependencies.
+namespace detail {
+
+inline constexpr u32 kCrc32Poly = 0xEDB88320u;
+
+inline constexpr auto buildCrc32Table() noexcept {
+    struct Table { u32 v[256] = {}; };
+    Table t{};
+    for (u32 i = 0; i < 256; ++i) {
+        u32 crc = i;
+        for (int j = 0; j < 8; ++j)
+            crc = (crc >> 1) ^ ((crc & 1) ? kCrc32Poly : 0u);
+        t.v[i] = crc;
+    }
+    return t;
+}
+
+inline constexpr auto kCrc32Table = buildCrc32Table();
+
+} // namespace detail
+
+// Returns CRC32 of [data, data+size).
+[[nodiscard]] inline u32 crc32(const void* data, u64 size) noexcept {
+    const auto* bytes = static_cast<const u8*>(data);
+    u32 crc = 0xFFFFFFFFu;
+    for (u64 i = 0; i < size; ++i)
+        crc = (crc >> 8) ^ detail::kCrc32Table.v[(crc ^ bytes[i]) & 0xFF];
+    return crc ^ 0xFFFFFFFFu;
+}
+
+// Continues an in-progress CRC32 computation (for streaming).
+[[nodiscard]] inline u32 crc32Continue(u32 prev, const void* data, u64 size) noexcept {
+    const auto* bytes = static_cast<const u8*>(data);
+    u32 crc = prev ^ 0xFFFFFFFFu;
+    for (u64 i = 0; i < size; ++i)
+        crc = (crc >> 8) ^ detail::kCrc32Table.v[(crc ^ bytes[i]) & 0xFF];
+    return crc ^ 0xFFFFFFFFu;
+}
+
+} // namespace Caffeine::IO

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CAFFEINE_TEST_SOURCES
     test_input.cpp
     test_debug.cpp
     test_jobsystem.cpp
+    test_caf.cpp
 )
 
 if(SDL3_FOUND)

--- a/tests/test_caf.cpp
+++ b/tests/test_caf.cpp
@@ -1,0 +1,310 @@
+#include "catch.hpp"
+#include "../src/core/io/CafTypes.hpp"
+#include "../src/core/io/Crc32.hpp"
+#include "../src/core/io/CafWriter.hpp"
+#include "../src/core/io/BlobLoader.hpp"
+#include "../src/memory/LinearAllocator.hpp"
+
+#include <cstring>
+
+using namespace Caffeine;
+using namespace Caffeine::IO;
+
+TEST_CASE("CafHeader - size is exactly 32 bytes", "[caf][types]") {
+    REQUIRE(sizeof(CafHeader) == 32);
+}
+
+TEST_CASE("CafHeader - magic constant is 0xCAFECAFE", "[caf][types]") {
+    REQUIRE(CafHeader::kMagic == 0xCAFECAFEu);
+}
+
+TEST_CASE("CafHeader - totalFileSize computes correctly", "[caf][types]") {
+    CafHeader h{};
+    h.metadataSize = 24;
+    h.dataSize     = 512;
+    REQUIRE(h.totalFileSize() == 32 + 24 + 512 + 4);
+}
+
+TEST_CASE("CafHeader - payloadAlignment returns 16 for Texture", "[caf][types]") {
+    CafHeader h{};
+    h.type = AssetType::Texture;
+    REQUIRE(h.payloadAlignment() == 16u);
+}
+
+TEST_CASE("CafHeader - payloadAlignment returns 32 for Mesh", "[caf][types]") {
+    CafHeader h{};
+    h.type = AssetType::Mesh;
+    REQUIRE(h.payloadAlignment() == 32u);
+}
+
+TEST_CASE("CafHeader - payloadAlignment returns 32 for Shader", "[caf][types]") {
+    CafHeader h{};
+    h.type = AssetType::Shader;
+    REQUIRE(h.payloadAlignment() == 32u);
+}
+
+TEST_CASE("TextureMetadata - size is 24 bytes", "[caf][types]") {
+    REQUIRE(sizeof(TextureMetadata) == 24);
+}
+
+TEST_CASE("AudioMetadata - size is 16 bytes", "[caf][types]") {
+    REQUIRE(sizeof(AudioMetadata) == 16);
+}
+
+TEST_CASE("SceneMetadata - size is 20 bytes", "[caf][types]") {
+    REQUIRE(sizeof(SceneMetadata) == 20);
+}
+
+TEST_CASE("ArchetypeDesc - size is 12 bytes", "[caf][types]") {
+    REQUIRE(sizeof(ArchetypeDesc) == 12);
+}
+
+TEST_CASE("ShaderMetadata - size is 8 bytes", "[caf][types]") {
+    REQUIRE(sizeof(ShaderMetadata) == 8);
+}
+
+TEST_CASE("crc32 - empty buffer produces 0x00000000", "[caf][crc32]") {
+    REQUIRE(crc32(nullptr, 0) == 0x00000000u);
+}
+
+TEST_CASE("crc32 - known vector '123456789' == 0xCBF43926", "[caf][crc32]") {
+    const char* data = "123456789";
+    REQUIRE(crc32(data, 9) == 0xCBF43926u);
+}
+
+TEST_CASE("crc32 - same data produces same result", "[caf][crc32]") {
+    const char data[] = "Caffeine Engine";
+    REQUIRE(crc32(data, sizeof(data)) == crc32(data, sizeof(data)));
+}
+
+TEST_CASE("crc32 - different data produces different result", "[caf][crc32]") {
+    const char a[] = "hello";
+    const char b[] = "world";
+    REQUIRE(crc32(a, sizeof(a)) != crc32(b, sizeof(b)));
+}
+
+TEST_CASE("crc32Continue - streaming equals single-shot", "[caf][crc32]") {
+    const char full[]  = "HelloWorld";
+    const char part1[] = "Hello";
+    const char part2[] = "World";
+
+    const u32 single   = crc32(full, 10);
+    const u32 first    = crc32(part1, 5);
+    const u32 combined = crc32Continue(first, part2, 5);
+
+    REQUIRE(single == combined);
+}
+
+TEST_CASE("CafWriter - writes valid texture .caf file", "[caf][writer]") {
+    TextureMetadata meta{};
+    meta.width     = 64;
+    meta.height    = 64;
+    meta.format    = 0;
+    meta.mipLevels = 1;
+    meta.reserved  = 0;
+
+    const u32 pixelCount = 64 * 64 * 4;
+    u8 pixels[64 * 64 * 4];
+    std::memset(pixels, 0xFF, pixelCount);
+
+    auto result = CafWriter::write(
+        "test_texture.caf",
+        AssetType::Texture,
+        CAF_FLAG_NONE,
+        &meta, sizeof(meta),
+        pixels, pixelCount);
+
+    REQUIRE(result.success);
+    REQUIRE(result.bytesWritten == 32 + sizeof(meta) + pixelCount + 4);
+
+    std::remove("test_texture.caf");
+}
+
+TEST_CASE("CafWriter - writes valid audio .caf file", "[caf][writer]") {
+    AudioMetadata meta{};
+    meta.sampleRate    = 44100;
+    meta.channels      = 2;
+    meta.bitsPerSample = 16;
+    meta.sampleCount   = 1000;
+    meta.reserved      = 0;
+
+    const u32 audioBytes = meta.sampleCount * meta.channels * (meta.bitsPerSample / 8);
+    u8 pcm[1000 * 2 * 2];
+    std::memset(pcm, 0, audioBytes);
+
+    auto result = CafWriter::write(
+        "test_audio.caf",
+        AssetType::Audio,
+        CAF_FLAG_NONE,
+        &meta, sizeof(meta),
+        pcm, audioBytes);
+
+    REQUIRE(result.success);
+
+    std::remove("test_audio.caf");
+}
+
+TEST_CASE("CafWriter - fails on invalid path", "[caf][writer]") {
+    u8 dummy[4] = {1, 2, 3, 4};
+    auto result = CafWriter::write(
+        "/nonexistent/dir/test.caf",
+        AssetType::Texture,
+        CAF_FLAG_NONE,
+        nullptr, 0,
+        dummy, sizeof(dummy));
+
+    REQUIRE_FALSE(result.success);
+    REQUIRE(result.bytesWritten == 0);
+}
+
+TEST_CASE("BlobLoader::validateHeader - rejects nonexistent file", "[caf][loader]") {
+    REQUIRE_FALSE(BlobLoader::validateHeader("no_such_file.caf"));
+}
+
+TEST_CASE("BlobLoader::validateHeader - accepts valid .caf file", "[caf][loader]") {
+    u8 payload[16];
+    std::memset(payload, 0xAB, sizeof(payload));
+
+    auto wr = CafWriter::write(
+        "test_validate.caf",
+        AssetType::Shader,
+        CAF_FLAG_NONE,
+        nullptr, 0,
+        payload, sizeof(payload));
+    REQUIRE(wr.success);
+
+    REQUIRE(BlobLoader::validateHeader("test_validate.caf"));
+
+    std::remove("test_validate.caf");
+}
+
+TEST_CASE("BlobLoader::load - loads texture asset correctly", "[caf][loader]") {
+    TextureMetadata meta{};
+    meta.width     = 4;
+    meta.height    = 4;
+    meta.mipLevels = 1;
+
+    const u32 payloadSize = 4 * 4 * 4;
+    u8 pixels[4 * 4 * 4];
+    for (u32 i = 0; i < payloadSize; ++i) pixels[i] = static_cast<u8>(i);
+
+    auto wr = CafWriter::write(
+        "test_load.caf",
+        AssetType::Texture,
+        CAF_FLAG_NONE,
+        &meta, sizeof(meta),
+        pixels, payloadSize);
+    REQUIRE(wr.success);
+
+    LinearAllocator alloc(4096);
+    auto lr = BlobLoader::load("test_load.caf", &alloc);
+
+    REQUIRE(lr.valid);
+    REQUIRE(lr.header   != nullptr);
+    REQUIRE(lr.metadata != nullptr);
+    REQUIRE(lr.payload  != nullptr);
+
+    REQUIRE(lr.header->magic    == CafHeader::kMagic);
+    REQUIRE(lr.header->type     == AssetType::Texture);
+    REQUIRE(lr.header->dataSize == payloadSize);
+
+    const auto* loadedMeta = static_cast<const TextureMetadata*>(lr.metadata);
+    REQUIRE(loadedMeta->width     == 4);
+    REQUIRE(loadedMeta->height    == 4);
+    REQUIRE(loadedMeta->mipLevels == 1);
+
+    REQUIRE(std::memcmp(lr.payload, pixels, payloadSize) == 0);
+
+    std::remove("test_load.caf");
+}
+
+TEST_CASE("BlobLoader::load - rejects nonexistent file", "[caf][loader]") {
+    LinearAllocator alloc(4096);
+    auto lr = BlobLoader::load("no_such_file.caf", &alloc);
+    REQUIRE_FALSE(lr.valid);
+}
+
+TEST_CASE("BlobLoader::load - rejects corrupt payload (CRC mismatch)", "[caf][loader]") {
+    u8 payload[32];
+    std::memset(payload, 0x55, sizeof(payload));
+
+    auto wr = CafWriter::write(
+        "test_corrupt.caf",
+        AssetType::Audio,
+        CAF_FLAG_NONE,
+        nullptr, 0,
+        payload, sizeof(payload));
+    REQUIRE(wr.success);
+
+    {
+        std::FILE* f = std::fopen("test_corrupt.caf", "r+b");
+        REQUIRE(f != nullptr);
+        std::fseek(f, 32 + 5, SEEK_SET);
+        u8 bad = 0xDE;
+        std::fwrite(&bad, 1, 1, f);
+        std::fclose(f);
+    }
+
+    LinearAllocator alloc(4096);
+    auto lr = BlobLoader::load("test_corrupt.caf", &alloc);
+    REQUIRE_FALSE(lr.valid);
+
+    std::remove("test_corrupt.caf");
+}
+
+TEST_CASE("BlobLoader::load - round-trips audio asset", "[caf][loader]") {
+    AudioMetadata meta{};
+    meta.sampleRate    = 48000;
+    meta.channels      = 1;
+    meta.bitsPerSample = 16;
+    meta.sampleCount   = 256;
+    meta.reserved      = 0;
+
+    const u32 audioBytes = 256 * 1 * 2;
+    u8 pcm[256 * 2];
+    for (u32 i = 0; i < audioBytes; ++i) pcm[i] = static_cast<u8>(i & 0xFF);
+
+    CafWriter::write(
+        "test_audio_rt.caf",
+        AssetType::Audio,
+        CAF_FLAG_NONE,
+        &meta, sizeof(meta),
+        pcm, audioBytes);
+
+    LinearAllocator alloc(8192);
+    auto lr = BlobLoader::load("test_audio_rt.caf", &alloc);
+
+    REQUIRE(lr.valid);
+    REQUIRE(lr.header->type == AssetType::Audio);
+
+    const auto* m = static_cast<const AudioMetadata*>(lr.metadata);
+    REQUIRE(m->sampleRate    == 48000u);
+    REQUIRE(m->channels      == 1u);
+    REQUIRE(m->bitsPerSample == 16u);
+    REQUIRE(m->sampleCount   == 256u);
+
+    REQUIRE(std::memcmp(lr.payload, pcm, audioBytes) == 0);
+
+    std::remove("test_audio_rt.caf");
+}
+
+TEST_CASE("BlobLoader::load - asset flags are preserved", "[caf][loader]") {
+    u8 payload[8] = {0};
+
+    CafWriter::write(
+        "test_flags.caf",
+        AssetType::Texture,
+        CAF_FLAG_SRGB | CAF_FLAG_MIPCHAIN,
+        nullptr, 0,
+        payload, sizeof(payload));
+
+    LinearAllocator alloc(1024);
+    auto lr = BlobLoader::load("test_flags.caf", &alloc);
+
+    REQUIRE(lr.valid);
+    REQUIRE((lr.header->flags & CAF_FLAG_SRGB)     != 0);
+    REQUIRE((lr.header->flags & CAF_FLAG_MIPCHAIN)  != 0);
+    REQUIRE((lr.header->flags & CAF_FLAG_COMPRESSED) == 0);
+
+    std::remove("test_flags.caf");
+}

--- a/tests/test_caf.cpp
+++ b/tests/test_caf.cpp
@@ -224,6 +224,32 @@ TEST_CASE("BlobLoader::load - rejects nonexistent file", "[caf][loader]") {
     REQUIRE_FALSE(lr.valid);
 }
 
+TEST_CASE("BlobLoader::load - rejects corrupt header (footer CRC mismatch)", "[caf][loader]") {
+    u8 payload[16] = {0};
+
+    CafWriter::write(
+        "test_corrupt_hdr.caf",
+        AssetType::Texture,
+        CAF_FLAG_NONE,
+        nullptr, 0,
+        payload, sizeof(payload));
+
+    {
+        std::FILE* f = std::fopen("test_corrupt_hdr.caf", "r+b");
+        REQUIRE(f != nullptr);
+        std::fseek(f, 4, SEEK_SET);
+        u16 bad = 0xDEAD;
+        std::fwrite(&bad, sizeof(u16), 1, f);
+        std::fclose(f);
+    }
+
+    LinearAllocator alloc(1024);
+    auto lr = BlobLoader::load("test_corrupt_hdr.caf", &alloc);
+    REQUIRE_FALSE(lr.valid);
+
+    std::remove("test_corrupt_hdr.caf");
+}
+
 TEST_CASE("BlobLoader::load - rejects corrupt payload (CRC mismatch)", "[caf][loader]") {
     u8 payload[32];
     std::memset(payload, 0x55, sizeof(payload));


### PR DESCRIPTION
File	Purpose
src/core/io/CafTypes.hpp	CafHeader (exactly 32 bytes, static_assert verified), AssetType enum, CafFlags, TextureMetadata, AudioMetadata, SceneMetadata, ArchetypeDesc, ShaderMetadata
src/core/io/Crc32.hpp	Header-only IEEE 802.3 CRC32 with constexpr lookup table; single-shot + streaming (crc32Continue)
src/core/io/BlobLoader.hpp/.cpp	Single-shot fread(), aligned IAllocator allocation, magic + payload CRC32 validation, zero-copy pointer setup
src/core/io/CafWriter.hpp/.cpp	Writes header + metadata + payload + 4-byte footer CRC32 in one pass
tests/test_caf.cpp	26 tests, 51 assertions — layout, sizes, CRC32 vectors, round-trips, corruption detection, flags