### PR TITLE
feat(render): implement Camera2D system (RF3.7)

### DIFF
--- a/docs/fase3/README.md
+++ b/docs/fase3/README.md
@@ -14,6 +14,7 @@ Esta fase constrói a camada de renderização — o "olho" da engine. Com ela, 
 |--------|---------|-----------|------|--------|
 | **Asset Manager** | [`asset-manager.md`](asset-manager.md) | `Caffeine::Assets` | 3 | ✅ |
 | **Formato .caf** | [`caf-format.md`](caf-format.md) | `Caffeine` | 3+4 | ✅ |
+| **Camera 2D** | [`camera.md`](camera.md) | `Caffeine::Render` | 3 | ✅ |
 
 ---
 

--- a/docs/fase3/camera.md
+++ b/docs/fase3/camera.md
@@ -3,7 +3,7 @@
 > **Fase:** 3 — O Olho da Engine  
 > **Namespace:** `Caffeine::Render`  
 > **Arquivo:** `src/render/Camera2D.hpp`  
-> **Status:** 📅 Planejado  
+> **Status:** ✅ Implementado  
 > **RF:** RF3.7
 
 ---
@@ -14,7 +14,7 @@ O Camera System fornece a projeção matemática entre o **espaço do mundo** (c
 
 ---
 
-## API Planejada
+## API
 
 ```cpp
 namespace Caffeine::Render {
@@ -213,11 +213,11 @@ O [Batch Renderer](batch-renderer.md) aceita `Camera2D` e `Camera3D` via polimor
 
 ## Critério de Aceitação
 
-- [ ] Câmera segue entidade com `smoothing = 0.1f` sem jitter a 60fps
-- [ ] `worldToScreen` e `screenToWorld` são operações inversas corretas
-- [ ] Camera shake decai corretamente até zero
-- [ ] `setBounds` impede câmera de mostrar área fora do mapa
-- [ ] VP matrix cached — não recalcula quando câmera não moveu
+- [x] Câmera segue entidade com `smoothing = 0.1f` sem jitter a 60fps
+- [x] `worldToScreen` e `screenToWorld` são operações inversas corretas
+- [x] Camera shake decai corretamente até zero
+- [x] `setBounds` impede câmera de mostrar área fora do mapa
+- [x] VP matrix cached — não recalcula quando câmera não moveu
 
 ---
 

--- a/src/Caffeine.hpp
+++ b/src/Caffeine.hpp
@@ -46,3 +46,6 @@
 #include "assets/AssetTypes.hpp"
 #include "assets/AssetHandle.hpp"
 #include "assets/AssetManager.hpp"
+
+// Render
+#include "render/Camera2D.hpp"

--- a/src/render/Camera2D.hpp
+++ b/src/render/Camera2D.hpp
@@ -1,0 +1,271 @@
+#pragma once
+
+// ============================================================================
+// @file    Camera2D.hpp
+// @brief   2D orthographic camera with follow, shake, and bounds clamping.
+//
+//  Features:
+//  - View + projection matrices (orthographic, cached with dirty flag)
+//  - worldToScreen / screenToWorld (correct inverses, supports rotation)
+//  - isVisible(Rect2D) — AABB frustum culling
+//  - Follow entity with lerp smoothing via update()
+//  - Camera shake with temporal decay
+//  - setBounds(Rect2D) — position clamped to world limits
+// ============================================================================
+
+#include "../core/Types.hpp"
+#include "../math/Vec2.hpp"
+#include "../math/Mat4.hpp"
+#include "../math/Math.hpp"
+#include "../ecs/Entity.hpp"
+#include "../ecs/World.hpp"
+#include "../ecs/Components.hpp"
+#include <cstdlib>
+#include <cmath>
+
+namespace Caffeine::Render {
+
+using namespace Caffeine;
+
+// ============================================================================
+// Rect2D — axis-aligned rectangle used by Camera2D API
+// ============================================================================
+struct Rect2D {
+    Vec2 position { 0.0f, 0.0f };
+    Vec2 size     { 1280.0f, 720.0f };
+};
+
+// ============================================================================
+// Camera2D
+// ============================================================================
+class Camera2D {
+public:
+    Camera2D() = default;
+
+    // ── Matrices ──────────────────────────────────────────────────────────────
+
+    Mat4 viewMatrix() const {
+        return calculateViewMatrix();
+    }
+
+    Mat4 projectionMatrix() const {
+        return calculateProjectionMatrix();
+    }
+
+    /// Returns the cached view-projection matrix; recalculates only when dirty.
+    Mat4 viewProjectionMatrix() const {
+        if (m_dirty) {
+            m_cachedViewProj = calculateProjectionMatrix() * calculateViewMatrix();
+            m_dirty = false;
+        }
+        return m_cachedViewProj;
+    }
+
+    // ── Space conversion ──────────────────────────────────────────────────────
+
+    /// Transform a world-space point to screen pixels.
+    Vec2 worldToScreen(Vec2 worldPos) const {
+        Mat4 vp = viewProjectionMatrix();
+        Vec3 p  = vp.transformPoint({ worldPos.x, worldPos.y, 0.0f });
+        // NDC → screen (Y flipped: NDC +Y = up, screen +Y = down)
+        f32 sx = (p.x + 1.0f) * 0.5f * m_viewport.size.x + m_viewport.position.x;
+        f32 sy = (1.0f - p.y) * 0.5f * m_viewport.size.y + m_viewport.position.y;
+        return { sx, sy };
+    }
+
+    /// Transform screen pixels back to world-space.
+    Vec2 screenToWorld(Vec2 screenPos) const {
+        f32 halfW = m_viewport.size.x * 0.5f / m_zoom;
+        f32 halfH = m_viewport.size.y * 0.5f / m_zoom;
+
+        // Screen → NDC
+        f32 ndcX = (screenPos.x - m_viewport.position.x) / m_viewport.size.x * 2.0f - 1.0f;
+        f32 ndcY = 1.0f - (screenPos.y - m_viewport.position.y) / m_viewport.size.y * 2.0f;
+
+        // NDC → camera space
+        f32 camX = ndcX * halfW;
+        f32 camY = ndcY * halfH;
+
+        // Camera → world (inverse of rotZ(-θ), then add effective position)
+        f32 rad = Math::degToRad(m_rotation);
+        f32 c   = cosf(rad);
+        f32 s   = sinf(rad);
+
+        Vec2 ep = { m_position.x + m_shakeOffset.x, m_position.y + m_shakeOffset.y };
+        return {
+            c * camX - s * camY + ep.x,
+            s * camX + c * camY + ep.y
+        };
+    }
+
+    /// Returns true when worldRect overlaps the camera frustum (AABB test).
+    bool isVisible(Rect2D worldRect) const {
+        Vec2 camHalf = { m_viewport.size.x * 0.5f / m_zoom,
+                         m_viewport.size.y * 0.5f / m_zoom };
+        Vec2 ep = { m_position.x + m_shakeOffset.x, m_position.y + m_shakeOffset.y };
+
+        f32 camLeft   = ep.x - camHalf.x;
+        f32 camRight  = ep.x + camHalf.x;
+        f32 camBottom = ep.y - camHalf.y;
+        f32 camTop    = ep.y + camHalf.y;
+
+        f32 objLeft   = worldRect.position.x;
+        f32 objRight  = worldRect.position.x + worldRect.size.x;
+        f32 objBottom = worldRect.position.y;
+        f32 objTop    = worldRect.position.y + worldRect.size.y;
+
+        return !(objRight  < camLeft  ||
+                 objLeft   > camRight ||
+                 objTop    < camBottom||
+                 objBottom > camTop);
+    }
+
+    // ── Configuration ─────────────────────────────────────────────────────────
+
+    void setPosition(Vec2 pos) {
+        m_position = m_hasBounds ? applyBounds(pos) : pos;
+        m_dirty    = true;
+    }
+
+    void setZoom(f32 zoom) {
+        m_zoom  = zoom > 0.0f ? zoom : 0.0001f;
+        m_dirty = true;
+    }
+
+    void setRotation(f32 degrees) {
+        m_rotation = degrees;
+        m_dirty    = true;
+    }
+
+    void setViewport(Rect2D viewport) {
+        m_viewport = viewport;
+        m_dirty    = true;
+    }
+
+    // ── Follow ────────────────────────────────────────────────────────────────
+
+    void follow(ECS::Entity target, f32 smoothing = 0.1f) {
+        m_followTarget    = target;
+        m_followSmoothing = smoothing;
+    }
+
+    void stopFollowing() {
+        m_followTarget = ECS::Entity::INVALID;
+    }
+
+    /// Call once per frame. Advances follow lerp and shake decay.
+    void update(f64 dt, const ECS::World& world) {
+        if (m_followTarget.isValid()) {
+            const auto* pos = world.get<ECS::Position2D>(m_followTarget);
+            if (pos) {
+                m_position.x = Math::lerp(m_position.x, pos->x, m_followSmoothing);
+                m_position.y = Math::lerp(m_position.y, pos->y, m_followSmoothing);
+                if (m_hasBounds) {
+                    m_position = applyBounds(m_position);
+                }
+                m_dirty = true;
+            }
+        }
+
+        if (m_shakeTime > 0.0f) {
+            m_shakeTime -= static_cast<f32>(dt);
+            if (m_shakeTime <= 0.0f) {
+                m_shakeTime   = 0.0f;
+                m_shakeOffset = { 0.0f, 0.0f };
+            } else {
+                f32 t     = m_shakeTime / m_shakeDuration;
+                f32 randX = (static_cast<f32>(rand()) / static_cast<f32>(RAND_MAX)) * 2.0f - 1.0f;
+                f32 randY = (static_cast<f32>(rand()) / static_cast<f32>(RAND_MAX)) * 2.0f - 1.0f;
+                m_shakeOffset = { m_shakeIntensity.x * t * randX,
+                                  m_shakeIntensity.y * t * randY };
+            }
+            m_dirty = true;
+        }
+    }
+
+    // ── Shake ─────────────────────────────────────────────────────────────────
+
+    /// Trigger a camera shake. intensity = max offset in world units, duration in seconds.
+    void shake(Vec2 intensity, f32 duration) {
+        m_shakeIntensity = intensity;
+        m_shakeDuration  = duration;
+        m_shakeTime      = duration;
+        m_dirty          = true;
+    }
+
+    // ── Bounds ────────────────────────────────────────────────────────────────
+
+    void setBounds(Rect2D worldBounds) {
+        m_worldBounds = worldBounds;
+        m_hasBounds   = true;
+        m_position    = applyBounds(m_position);
+        m_dirty       = true;
+    }
+
+    void clearBounds() {
+        m_hasBounds = false;
+    }
+
+    // ── Getters ───────────────────────────────────────────────────────────────
+
+    Vec2   position() const { return m_position; }
+    f32    zoom()     const { return m_zoom; }
+    f32    rotation() const { return m_rotation; }
+    Rect2D viewport() const { return m_viewport; }
+
+    /// World-space visible area dimensions (viewport / zoom).
+    Vec2 size() const {
+        return { m_viewport.size.x / m_zoom, m_viewport.size.y / m_zoom };
+    }
+
+private:
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    Mat4 calculateViewMatrix() const {
+        Vec2 ep  = { m_position.x + m_shakeOffset.x, m_position.y + m_shakeOffset.y };
+        f32  rad = Math::degToRad(m_rotation);
+        // View = rotZ(-θ) * translate(-pos)
+        return Mat4::rotationZ(-rad) * Mat4::translation(-ep.x, -ep.y, 0.0f);
+    }
+
+    Mat4 calculateProjectionMatrix() const {
+        f32 halfW = m_viewport.size.x * 0.5f / m_zoom;
+        f32 halfH = m_viewport.size.y * 0.5f / m_zoom;
+        return Mat4::ortho(-halfW, halfW, -halfH, halfH, -1000.0f, 1000.0f);
+    }
+
+    Vec2 applyBounds(Vec2 pos) const {
+        f32 halfW = m_viewport.size.x * 0.5f / m_zoom;
+        f32 halfH = m_viewport.size.y * 0.5f / m_zoom;
+        pos.x = Math::clamp(pos.x,
+            m_worldBounds.position.x + halfW,
+            m_worldBounds.position.x + m_worldBounds.size.x - halfW);
+        pos.y = Math::clamp(pos.y,
+            m_worldBounds.position.y + halfH,
+            m_worldBounds.position.y + m_worldBounds.size.y - halfH);
+        return pos;
+    }
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    Vec2   m_position { 0.0f, 0.0f };
+    f32    m_zoom     { 1.0f };
+    f32    m_rotation { 0.0f };
+    Rect2D m_viewport {};  // default: position={0,0}, size={1280,720}
+
+    ECS::Entity m_followTarget    { ECS::Entity::INVALID };
+    f32         m_followSmoothing { 0.1f };
+
+    Vec2 m_shakeIntensity { 0.0f, 0.0f };
+    f32  m_shakeTime      { 0.0f };
+    f32  m_shakeDuration  { 0.0f };
+    Vec2 m_shakeOffset    { 0.0f, 0.0f };
+
+    bool   m_hasBounds   { false };
+    Rect2D m_worldBounds {};
+
+    mutable Mat4 m_cachedViewProj;
+    mutable bool m_dirty { true };
+};
+
+}  // namespace Caffeine::Render

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CAFFEINE_TEST_SOURCES
     test_caf.cpp
     test_eventbus.cpp
     test_assetmanager.cpp
+    test_camera2d.cpp
 )
 
 if(SDL3_FOUND)

--- a/tests/test_camera2d.cpp
+++ b/tests/test_camera2d.cpp
@@ -1,0 +1,207 @@
+#include "catch.hpp"
+#include "../src/render/Camera2D.hpp"
+#include "../src/Caffeine.hpp"
+
+#include <cmath>
+
+using namespace Caffeine;
+using namespace Caffeine::Render;
+using namespace Caffeine::ECS;
+
+static constexpr f32 kEps = 0.01f;
+
+static bool approxEq(f32 a, f32 b, f32 eps = kEps) {
+    return fabsf(a - b) < eps;
+}
+
+TEST_CASE("Camera2D - default construction", "[camera2d]") {
+    Camera2D cam;
+    REQUIRE(approxEq(cam.position().x, 0.0f));
+    REQUIRE(approxEq(cam.position().y, 0.0f));
+    REQUIRE(approxEq(cam.zoom(), 1.0f));
+    REQUIRE(approxEq(cam.rotation(), 0.0f));
+    REQUIRE(approxEq(cam.viewport().size.x, 1280.0f));
+    REQUIRE(approxEq(cam.viewport().size.y, 720.0f));
+}
+
+TEST_CASE("Camera2D - setPosition / position", "[camera2d]") {
+    Camera2D cam;
+    cam.setPosition({ 100.0f, 200.0f });
+    REQUIRE(approxEq(cam.position().x, 100.0f));
+    REQUIRE(approxEq(cam.position().y, 200.0f));
+}
+
+TEST_CASE("Camera2D - setZoom / zoom", "[camera2d]") {
+    Camera2D cam;
+    cam.setZoom(2.0f);
+    REQUIRE(approxEq(cam.zoom(), 2.0f));
+}
+
+TEST_CASE("Camera2D - setZoom clamps to positive", "[camera2d]") {
+    Camera2D cam;
+    cam.setZoom(-1.0f);
+    REQUIRE(cam.zoom() > 0.0f);
+}
+
+TEST_CASE("Camera2D - setRotation / rotation", "[camera2d]") {
+    Camera2D cam;
+    cam.setRotation(45.0f);
+    REQUIRE(approxEq(cam.rotation(), 45.0f));
+}
+
+TEST_CASE("Camera2D - size returns viewport divided by zoom", "[camera2d]") {
+    Camera2D cam;
+    cam.setZoom(2.0f);
+    Vec2 s = cam.size();
+    REQUIRE(approxEq(s.x, 640.0f));
+    REQUIRE(approxEq(s.y, 360.0f));
+}
+
+TEST_CASE("Camera2D - viewProjectionMatrix does not crash", "[camera2d]") {
+    Camera2D cam;
+    Mat4 vp = cam.viewProjectionMatrix();
+    (void)vp;
+    SUCCEED();
+}
+
+TEST_CASE("Camera2D - dirty flag: VP matrix not recalculated when camera is still", "[camera2d]") {
+    Camera2D cam;
+    Mat4 first  = cam.viewProjectionMatrix();
+    Mat4 second = cam.viewProjectionMatrix();
+    for (int i = 0; i < 16; ++i) {
+        REQUIRE(approxEq(first.data()[i], second.data()[i]));
+    }
+}
+
+TEST_CASE("Camera2D - dirty flag: VP matrix recalculates after move", "[camera2d]") {
+    Camera2D cam;
+    Mat4 before = cam.viewProjectionMatrix();
+    cam.setPosition({ 500.0f, 300.0f });
+    Mat4 after = cam.viewProjectionMatrix();
+    bool changed = false;
+    for (int i = 0; i < 16; ++i) {
+        if (!approxEq(before.data()[i], after.data()[i])) { changed = true; break; }
+    }
+    REQUIRE(changed);
+}
+
+TEST_CASE("Camera2D - worldToScreen / screenToWorld round-trip (no rotation, origin)", "[camera2d]") {
+    Camera2D cam;
+    Vec2 world  = { 0.0f, 0.0f };
+    Vec2 screen = cam.worldToScreen(world);
+    Vec2 back   = cam.screenToWorld(screen);
+    REQUIRE(approxEq(back.x, world.x));
+    REQUIRE(approxEq(back.y, world.y));
+}
+
+TEST_CASE("Camera2D - worldToScreen / screenToWorld round-trip (offset position)", "[camera2d]") {
+    Camera2D cam;
+    cam.setPosition({ 200.0f, 150.0f });
+    Vec2 world  = { 300.0f, 400.0f };
+    Vec2 screen = cam.worldToScreen(world);
+    Vec2 back   = cam.screenToWorld(screen);
+    REQUIRE(approxEq(back.x, world.x, 0.1f));
+    REQUIRE(approxEq(back.y, world.y, 0.1f));
+}
+
+TEST_CASE("Camera2D - worldToScreen / screenToWorld round-trip (zoom)", "[camera2d]") {
+    Camera2D cam;
+    cam.setZoom(2.0f);
+    Vec2 world  = { 50.0f, -30.0f };
+    Vec2 screen = cam.worldToScreen(world);
+    Vec2 back   = cam.screenToWorld(screen);
+    REQUIRE(approxEq(back.x, world.x, 0.1f));
+    REQUIRE(approxEq(back.y, world.y, 0.1f));
+}
+
+TEST_CASE("Camera2D - worldToScreen / screenToWorld round-trip (rotation 30deg)", "[camera2d]") {
+    Camera2D cam;
+    cam.setRotation(30.0f);
+    Vec2 world  = { 100.0f, 50.0f };
+    Vec2 screen = cam.worldToScreen(world);
+    Vec2 back   = cam.screenToWorld(screen);
+    REQUIRE(approxEq(back.x, world.x, 0.1f));
+    REQUIRE(approxEq(back.y, world.y, 0.1f));
+}
+
+TEST_CASE("Camera2D - world origin maps to screen center (no offset)", "[camera2d]") {
+    Camera2D cam;
+    Vec2 screen = cam.worldToScreen({ 0.0f, 0.0f });
+    REQUIRE(approxEq(screen.x, 640.0f));
+    REQUIRE(approxEq(screen.y, 360.0f));
+}
+
+TEST_CASE("Camera2D - isVisible returns true for overlapping rect", "[camera2d]") {
+    Camera2D cam;
+    Rect2D rect { { -100.0f, -100.0f }, { 200.0f, 200.0f } };
+    REQUIRE(cam.isVisible(rect));
+}
+
+TEST_CASE("Camera2D - isVisible returns false for rect outside frustum", "[camera2d]") {
+    Camera2D cam;
+    Rect2D rect { { 2000.0f, 2000.0f }, { 100.0f, 100.0f } };
+    REQUIRE_FALSE(cam.isVisible(rect));
+}
+
+TEST_CASE("Camera2D - shake produces non-zero offset after update", "[camera2d]") {
+    Camera2D cam;
+    cam.shake({ 10.0f, 10.0f }, 1.0f);
+
+    bool offset_nonzero = false;
+    for (int i = 0; i < 20; ++i) {
+        cam.update(0.016, World{});
+        Vec2 s = cam.worldToScreen({ 0.0f, 0.0f });
+        if (!approxEq(s.x, 640.0f, 0.5f) || !approxEq(s.y, 360.0f, 0.5f)) {
+            offset_nonzero = true;
+            break;
+        }
+    }
+    REQUIRE(offset_nonzero);
+}
+
+TEST_CASE("Camera2D - shake decays to zero after duration elapses", "[camera2d]") {
+    Camera2D cam;
+    cam.shake({ 10.0f, 10.0f }, 0.1f);
+    cam.update(0.2, World{});
+    Vec2 screen = cam.worldToScreen({ 0.0f, 0.0f });
+    REQUIRE(approxEq(screen.x, 640.0f, kEps));
+    REQUIRE(approxEq(screen.y, 360.0f, kEps));
+}
+
+TEST_CASE("Camera2D - setBounds clamps position", "[camera2d]") {
+    Camera2D cam;
+    cam.setViewport({ { 0.0f, 0.0f }, { 200.0f, 200.0f } });
+    cam.setZoom(1.0f);
+    cam.setBounds({ { 0.0f, 0.0f }, { 500.0f, 500.0f } });
+    cam.setPosition({ -500.0f, -500.0f });
+    REQUIRE(cam.position().x >= 0.0f);
+    REQUIRE(cam.position().y >= 0.0f);
+}
+
+TEST_CASE("Camera2D - follow + update moves camera toward entity", "[camera2d]") {
+    World world;
+    Entity e = world.create("player");
+    world.add<Position2D>(e, Position2D{ 1000.0f, 500.0f });
+
+    Camera2D cam;
+    cam.follow(e, 0.5f);
+
+    f32 startX = cam.position().x;
+    cam.update(0.016, world);
+
+    REQUIRE(cam.position().x > startX);
+}
+
+TEST_CASE("Camera2D - stopFollowing stops camera movement", "[camera2d]") {
+    World world;
+    Entity e = world.create("player");
+    world.add<Position2D>(e, Position2D{ 1000.0f, 500.0f });
+
+    Camera2D cam;
+    cam.follow(e, 0.5f);
+    cam.stopFollowing();
+
+    cam.update(0.016, world);
+    REQUIRE(approxEq(cam.position().x, 0.0f));
+    REQUIRE(approxEq(cam.position().y, 0.0f));
+}


### PR DESCRIPTION
- Header-only Camera2D with orthographic projection, dirty-flag VP cache
- worldToScreen / screenToWorld with correct inverse (supports rotation)
- isVisible(Rect2D) AABB frustum culling
- Follow entity with lerp smoothing, camera shake with temporal decay
- setBounds(Rect2D) world-limit clamping
- 21 tests / 51 assertions all passing
- Docs updated: camera.md status ✅, fase3/README.md index