### PR TITLE
feat(spatial): implement Octree spatial partitioning with AABB3D and Frustum (RF5.4)

### DIFF
--- a/docs/fase5/spatial-partitioning.md
+++ b/docs/fase5/spatial-partitioning.md
@@ -3,7 +3,7 @@
 > **Fase:** 5 — Transição Dimensional  
 > **Namespace:** `Caffeine::Spatial`  
 > **Arquivo:** `src/spatial/Octree.hpp`  
-> **Status:** 📅 Planejado  
+> **Status:** ✅ Implementado  
 > **RF:** RF5.4
 
 ---
@@ -36,13 +36,18 @@ struct AABB3D {
 // ============================================================================
 // @brief  Frustum para culling.
 //
-//  Derivado da view-projection matrix.
 //  Planos: Near, Far, Left, Right, Top, Bottom.
+//  Convenção: d ≤ 0 → dentro, d > 0 → fora.
 // ============================================================================
 struct Frustum {
     Vec4 planes[6];   // Ax + By + Cz + D = 0 (normalizados)
 
-    static Frustum fromMatrix(const Math::Mat4& viewProj);
+    // fromCamera() é o método recomendado — funciona com qualquer
+    // convenção de projeção pois constrói os planos da geometria.
+    // fromMatrix() requer matriz VP estilo OpenGL padrão.
+    static Frustum fromCamera(Vec3 eye, Vec3 target, Vec3 up,
+                               f32 fovY, f32 aspect, f32 nearZ, f32 farZ);
+    static Frustum fromMatrix(const Mat4& viewProj);
 
     bool contains(Vec3 point)      const;
     bool intersects(const AABB3D& aabb) const;
@@ -114,11 +119,10 @@ private:
 ## Frustum Culling (RF5.6)
 
 ```
-Camera3D
-  └── viewProjectionMatrix()
+Câmera (eye, target, up, fov, aspect, near, far)
         │
         ▼
-  Frustum::fromMatrix(viewProj)
+  Frustum::fromCamera(eye, target, up, fovY, aspect, nearZ, farZ)
         │
         ▼
   Octree::queryFrustum(frustum, visibleEntities)
@@ -127,6 +131,10 @@ Camera3D
   Apenas entidades DENTRO do frustum são enviadas ao MeshSystem
   (entidades fora não geram draw calls)
 ```
+
+> **Nota:** `Frustum::fromMatrix()` está disponível para matrizes VP estilo
+> OpenGL padrão, mas não funciona com a `Mat4::perspective()` da Caffeine
+> (que possui layout Z/W trocado). Prefira `fromCamera()` sempre que possível.
 
 **Benefício:** Em uma cena com 10K objetos, apenas os ~100 visíveis geram draw calls.
 
@@ -165,7 +173,10 @@ world.query(meshQuery, [&](ECS::Entity e, Position3D& pos, MeshRenderer& mr) {
 });
 
 // ── Frustum culling ───────────────────────────────────────────
-Frustum frustum = Frustum::fromMatrix(camera3D.viewProjectionMatrix());
+Frustum frustum = Frustum::fromCamera(
+    camera3D.position(), camera3D.target(), camera3D.up(),
+    camera3D.fovY(), camera3D.aspect(), camera3D.nearZ(), camera3D.farZ()
+);
 std::vector<ECS::Entity> visible;
 octree.queryFrustum(frustum, visible);
 
@@ -185,10 +196,13 @@ if (entity.get<Position3D>().changed) {
 
 ## Critério de Aceitação
 
-- [ ] `queryFrustum` exclui corretamente entidades fora do frustum
-- [ ] Performance: 10K entidades, query em < 1ms
-- [ ] `insert`/`remove` corretos sem corrupção
-- [ ] Frustum culling: entidades fora da câmera não geram draw calls
+- [x] `AABB3D` — center, size, contains (point/AABB), intersects, intersectsRay
+- [x] `Frustum::fromCamera` — construção robusta a partir de parâmetros de câmera
+- [x] `Frustum::contains` / `intersects` / `containsSphere` — testes com pontos, AABBs e esferas
+- [x] `Octree` — insert, remove, update, rebuild, queries (AABB/Frustum/Ray/Radius)
+- [x] `Octree` — subdivisão automática, profundidade máxima, contagem consistente
+- [ ] Performance bench: 10K entidades, query em < 1ms (benchmark pendente)
+- [ ] Integração com Camera3D + MeshSystem para culling em draw calls
 
 ---
 

--- a/src/Caffeine.hpp
+++ b/src/Caffeine.hpp
@@ -60,6 +60,9 @@
 #include "scene/SceneSerializer.hpp"
 #include "scene/SceneManager.hpp"
 
+// Spatial
+#include "spatial/Octree.hpp"
+
 // Physics
 #include "physics/PhysicsComponents2D.hpp"
 #include "physics/PhysicsSystem2D.hpp"

--- a/src/spatial/Octree.hpp
+++ b/src/spatial/Octree.hpp
@@ -1,0 +1,491 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "math/Vec3.hpp"
+#include "math/Vec4.hpp"
+#include "math/Mat4.hpp"
+#include "math/Math.hpp"
+#include "ecs/Entity.hpp"
+
+#include <memory>
+#include <vector>
+#include <cmath>
+
+namespace Caffeine::Spatial {
+using namespace Caffeine;
+
+// ============================================================================
+// AABB 3D — axis-aligned bounding box
+// ============================================================================
+struct AABB3D {
+    Vec3 min = {0, 0, 0};
+    Vec3 max = {0, 0, 0};
+
+    Vec3 center() const { return (min + max) * 0.5f; }
+    Vec3 size()   const { return max - min; }
+
+    bool contains(Vec3 p) const {
+        return (p.x >= min.x && p.x <= max.x &&
+                p.y >= min.y && p.y <= max.y &&
+                p.z >= min.z && p.z <= max.z);
+    }
+
+    bool contains(const AABB3D& o) const {
+        return (o.min.x >= min.x && o.max.x <= max.x &&
+                o.min.y >= min.y && o.max.y <= max.y &&
+                o.min.z >= min.z && o.max.z <= max.z);
+    }
+
+    bool intersects(const AABB3D& o) const {
+        return (min.x <= o.max.x && max.x >= o.min.x &&
+                min.y <= o.max.y && max.y >= o.min.y &&
+                min.z <= o.max.z && max.z >= o.min.z);
+    }
+
+    // Ray-AABB using the slab method.
+    bool intersectsRay(Vec3 origin, Vec3 dir, f32* tMinOut = nullptr) const {
+        f32 tMin = -1e30f;
+        f32 tMax =  1e30f;
+
+        for (u32 axis = 0; axis < 3; ++axis) {
+            f32 o = (&origin.x)[axis];
+            f32 d = (&dir.x)[axis];
+            f32 mn = (&min.x)[axis];
+            f32 mx = (&max.x)[axis];
+
+            if (Math::absf(d) < 1e-8f) {
+                if (o < mn || o > mx) return false;
+            } else {
+                f32 t1 = (mn - o) / d;
+                f32 t2 = (mx - o) / d;
+                if (t1 > t2) { f32 tmp = t1; t1 = t2; t2 = tmp; }
+                if (t1 > tMin) tMin = t1;
+                if (t2 < tMax) tMax = t2;
+                if (tMin > tMax || tMax < 0.0f) return false;
+            }
+        }
+
+        if (tMinOut) *tMinOut = (tMin > 0.0f) ? tMin : 0.0f;
+        return true;
+    }
+};
+
+
+// ============================================================================
+// Frustum for culling.
+//
+// Planes stored as (A,B,C,D) where Ax+By+Cz+D=0.
+// Our convention: d <= 0 is inside, d > 0 is outside.
+//
+// Use fromCamera() for robust construction from camera parameters.
+// fromMatrix() requires a standard OpenGL-style projection matrix.
+// ============================================================================
+struct Frustum {
+    enum Plane { Left = 0, Right, Bottom, Top, Near, Far, PlaneCount };
+    Vec4 planes[PlaneCount];
+
+    static Frustum fromMatrix(const Mat4& viewProj) {
+        Frustum f;
+
+        Vec4 row0(viewProj(0,0), viewProj(0,1), viewProj(0,2), viewProj(0,3));
+        Vec4 row1(viewProj(1,0), viewProj(1,1), viewProj(1,2), viewProj(1,3));
+        Vec4 row2(viewProj(2,0), viewProj(2,1), viewProj(2,2), viewProj(2,3));
+        Vec4 row3(viewProj(3,0), viewProj(3,1), viewProj(3,2), viewProj(3,3));
+
+        // Gribb & Hartmann: (row3 ± rowN) gives d >= 0 = inside.
+        // Negate components for our d <= 0 = inside convention.
+        auto neg = [](const Vec4& v) { return Vec4(-v.x, -v.y, -v.z, -v.w); };
+        f.planes[Left]   = neg(row3 + row0);
+        f.planes[Right]  = neg(row3 - row0);
+        f.planes[Bottom] = neg(row3 + row1);
+        f.planes[Top]    = neg(row3 - row1);
+        f.planes[Near]   = neg(row3 + row2);
+        f.planes[Far]    = neg(row3 - row2);
+
+        for (u32 i = 0; i < PlaneCount; ++i) {
+            Vec4& p = f.planes[i];
+            f32 len = sqrtf(p.x * p.x + p.y * p.y + p.z * p.z);
+            if (len > 1e-8f) {
+                f32 inv = 1.0f / len;
+                p.x *= inv; p.y *= inv; p.z *= inv; p.w *= inv;
+            }
+        }
+        return f;
+    }
+
+    static Frustum fromCamera(Vec3 eye, Vec3 target, Vec3 up,
+                               f32 fovY, f32 aspect, f32 nearZ, f32 farZ) {
+        Frustum f;
+
+        Vec3 forward = (target - eye).normalized();
+        Vec3 right   = forward.cross(up).normalized();
+        Vec3 upDir   = right.cross(forward);
+
+        f32 tanHalf = tanf(fovY * 0.5f);
+        f32 tanH    = tanHalf * aspect; // horizontal half-tan
+
+        Vec3 nc = eye + forward * nearZ;
+        Vec3 fc = eye + forward * farZ;
+
+        // Helper: make a plane from a point and inward (standard) normal,
+        // then negate so our d <= 0 = inside convention holds.
+        auto makePlane = [](Vec3 pointOnPlane, Vec3 inwardNormal) -> Vec4 {
+            f32 D = -inwardNormal.dot(pointOnPlane);
+            f32 len = inwardNormal.length();
+            return {-inwardNormal.x / len, -inwardNormal.y / len,
+                    -inwardNormal.z / len, -D / len};
+        };
+
+        f.planes[Near] = makePlane(nc, forward);
+        f.planes[Far]  = makePlane(fc, Vec3(-forward.x, -forward.y, -forward.z));
+
+        // Side plane inward normals derived from view-space frustum geometry.
+        // In view space (camera at origin, looking down -Z):
+        //   Left:  x - z*tanH  = 0 → inward normal = ( 1, 0, -tanH)
+        //   Right: x + z*tanH  = 0 → inward normal = (-1, 0, -tanH)
+        //   Top:   y + z*tanY  = 0 → inward normal = ( 0, -1, -tanY)
+        //   Bottom: y - z*tanY = 0 → inward normal = ( 0,  1, -tanY)
+        // Transform to world via: n_world = R^T * n_view, where R^T columns are
+        // (right, upDir, -forward). All side planes pass through eye.
+        auto sidePlane = [&](Vec3 nView) -> Vec4 {
+            Vec3 nw = right * nView.x + upDir * nView.y + Vec3(-forward.x, -forward.y, -forward.z) * nView.z;
+            f32 len = nw.length();
+            f32 D = -nw.dot(eye);
+            return {-nw.x / len, -nw.y / len, -nw.z / len, -D / len};
+        };
+
+        f.planes[Left]   = sidePlane(Vec3( 1.0f,  0.0f, -tanH));
+        f.planes[Right]  = sidePlane(Vec3(-1.0f,  0.0f, -tanH));
+        f.planes[Top]    = sidePlane(Vec3( 0.0f, -1.0f, -tanHalf));
+        f.planes[Bottom] = sidePlane(Vec3( 0.0f,  1.0f, -tanHalf));
+
+        return f;
+    }
+
+    bool contains(Vec3 point) const {
+        for (u32 i = 0; i < PlaneCount; ++i) {
+            f32 d = planes[i].x * point.x +
+                    planes[i].y * point.y +
+                    planes[i].z * point.z +
+                    planes[i].w;
+            if (d > 0.0f) return false;
+        }
+        return true;
+    }
+
+    bool intersects(const AABB3D& aabb) const {
+        for (u32 i = 0; i < PlaneCount; ++i) {
+            const Vec4& p = planes[i];
+            // p-vertex: the AABB corner with the LEAST signed distance to the
+            // plane (furthest inside for our d <= 0 = inside convention).
+            f32 px = p.x >= 0.0f ? aabb.min.x : aabb.max.x;
+            f32 py = p.y >= 0.0f ? aabb.min.y : aabb.max.y;
+            f32 pz = p.z >= 0.0f ? aabb.min.z : aabb.max.z;
+            if (p.x * px + p.y * py + p.z * pz + p.w > 0.0f)
+                return false;
+        }
+        return true;
+    }
+
+    bool containsSphere(Vec3 center, f32 radius) const {
+        for (u32 i = 0; i < PlaneCount; ++i) {
+            f32 d = planes[i].x * center.x +
+                    planes[i].y * center.y +
+                    planes[i].z * center.z +
+                    planes[i].w;
+            if (d - radius > 0.0f) return false;
+        }
+        return true;
+    }
+};
+
+
+// ============================================================================
+// Octree for 3D spatial partitioning.
+//
+// Each node subdivides into 8 children when exceeding maxEntitiesPerNode.
+// Entities are inserted by AABB center point and stored in leaf nodes.
+// ============================================================================
+class Octree {
+public:
+    struct Config {
+        AABB3D rootBounds;
+        u32    maxEntitiesPerNode = 8;
+        u32    maxDepth           = 8;
+    };
+
+    explicit Octree(const Config& cfg) : m_config(cfg) {
+        m_root.bounds = cfg.rootBounds;
+        m_root.depth  = 0;
+    }
+
+    // ── Insert / Remove / Update ───────────────────────────────
+
+    void insert(ECS::Entity entity, const AABB3D& bounds) {
+        insertRecursive(&m_root, entity, bounds);
+    }
+
+    void remove(ECS::Entity entity) {
+        removeRecursive(&m_root, entity);
+    }
+
+    void update(ECS::Entity entity, const AABB3D& newBounds) {
+        remove(entity);
+        insert(entity, newBounds);
+    }
+
+    void rebuild() {
+        std::vector<Entry> all;
+        collectEntries(&m_root, all);
+
+        m_root = Node();
+        m_root.bounds = m_config.rootBounds;
+        m_root.depth  = 0;
+
+        for (auto& e : all) {
+            insertRecursive(&m_root, e.entity, e.bounds);
+        }
+    }
+
+    // ── Queries ────────────────────────────────────────────────
+
+    void queryAABB(const AABB3D& queryBounds,
+                   std::vector<ECS::Entity>& out) const {
+        queryAABBRecursive(&m_root, queryBounds, out);
+    }
+
+    void queryFrustum(const Frustum& frustum,
+                      std::vector<ECS::Entity>& out) const {
+        queryFrustumRecursive(&m_root, frustum, out);
+    }
+
+    void queryRay(Vec3 origin, Vec3 dir, f32 maxDist,
+                  std::vector<ECS::Entity>& out) const {
+        queryRayRecursive(&m_root, origin, dir, maxDist, out);
+    }
+
+    void queryRadius(Vec3 center, f32 radius,
+                     std::vector<ECS::Entity>& out) const {
+        queryRadiusRecursive(&m_root, center, radius, out);
+    }
+
+    // ── Stats ──────────────────────────────────────────────────
+
+    u32 nodeCount()   const { return nodeCountRecursive(&m_root); }
+    u32 entityCount() const { return entityCountRecursive(&m_root); }
+    u32 depth()       const { return depthRecursive(&m_root); }
+
+private:
+    struct Entry { ECS::Entity entity; AABB3D bounds; };
+
+    struct Node {
+        AABB3D                         bounds;
+        std::vector<Entry>             entries;
+        std::unique_ptr<Node>          children[8]{};
+        bool                           isLeaf = true;
+        u32                            depth  = 0;
+
+        int childIndex(Vec3 point) const {
+            Vec3 c = bounds.center();
+            int idx = 0;
+            if (point.x >= c.x) idx |= 1;
+            if (point.y >= c.y) idx |= 2;
+            if (point.z >= c.z) idx |= 4;
+            return idx;
+        }
+
+        void subdivide() {
+            Vec3 c = bounds.center();
+            for (int i = 0; i < 8; ++i) {
+                auto ch = std::make_unique<Node>();
+                ch->bounds.min = {
+                    (i & 1) ? c.x : bounds.min.x,
+                    (i & 2) ? c.y : bounds.min.y,
+                    (i & 4) ? c.z : bounds.min.z
+                };
+                ch->bounds.max = {
+                    (i & 1) ? bounds.max.x : c.x,
+                    (i & 2) ? bounds.max.y : c.y,
+                    (i & 4) ? bounds.max.z : c.z
+                };
+                ch->depth  = depth + 1;
+                ch->isLeaf = true;
+                children[i] = std::move(ch);
+            }
+            isLeaf = false;
+        }
+    };
+
+    Node   m_root;
+    Config m_config;
+
+    // ── Recursive helpers ──────────────────────────────────────
+
+    void insertRecursive(Node* node, ECS::Entity entity, const AABB3D& bounds) {
+        if (!node->isLeaf) {
+            int idx = node->childIndex(bounds.center());
+            insertRecursive(node->children[idx].get(), entity, bounds);
+            return;
+        }
+
+        node->entries.push_back({entity, bounds});
+
+        if (node->entries.size() > m_config.maxEntitiesPerNode &&
+            node->depth < m_config.maxDepth) {
+            node->subdivide();
+            auto old = std::move(node->entries);
+            for (auto& e : old) {
+                int idx = node->childIndex(e.bounds.center());
+                node->children[idx]->entries.push_back(std::move(e));
+            }
+        }
+    }
+
+    static bool removeRecursive(Node* node, ECS::Entity entity) {
+        if (node->isLeaf) {
+            for (auto it = node->entries.begin(); it != node->entries.end(); ++it) {
+                if (it->entity == entity) {
+                    node->entries.erase(it);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        for (u32 i = 0; i < 8; ++i) {
+            if (node->children[i] && removeRecursive(node->children[i].get(), entity))
+                return true;
+        }
+        return false;
+    }
+
+    static void collectEntries(Node* node, std::vector<Entry>& out) {
+        for (auto& e : node->entries)
+            out.push_back(e);
+        if (!node->isLeaf) {
+            for (u32 i = 0; i < 8; ++i) {
+                if (node->children[i])
+                    collectEntries(node->children[i].get(), out);
+            }
+        }
+    }
+
+    static void queryAABBRecursive(const Node* node, const AABB3D& q,
+                                   std::vector<ECS::Entity>& out) {
+        if (!node->bounds.intersects(q)) return;
+
+        if (node->isLeaf) {
+            for (auto& e : node->entries) {
+                if (e.bounds.intersects(q))
+                    out.push_back(e.entity);
+            }
+            return;
+        }
+
+        for (u32 i = 0; i < 8; ++i) {
+            if (node->children[i])
+                queryAABBRecursive(node->children[i].get(), q, out);
+        }
+    }
+
+    static void queryFrustumRecursive(const Node* node, const Frustum& f,
+                                      std::vector<ECS::Entity>& out) {
+        if (!f.intersects(node->bounds)) return;
+
+        if (node->isLeaf) {
+            for (auto& e : node->entries) {
+                if (f.intersects(e.bounds))
+                    out.push_back(e.entity);
+            }
+            return;
+        }
+
+        for (u32 i = 0; i < 8; ++i) {
+            if (node->children[i])
+                queryFrustumRecursive(node->children[i].get(), f, out);
+        }
+    }
+
+    static void queryRayRecursive(const Node* node, Vec3 origin, Vec3 dir,
+                                  f32 maxDist, std::vector<ECS::Entity>& out) {
+        f32 tHit;
+        if (!node->bounds.intersectsRay(origin, dir, &tHit) || tHit > maxDist)
+            return;
+
+        if (node->isLeaf) {
+            for (auto& e : node->entries) {
+                f32 tE;
+                if (e.bounds.intersectsRay(origin, dir, &tE) && tE <= maxDist)
+                    out.push_back(e.entity);
+            }
+            return;
+        }
+
+        for (u32 i = 0; i < 8; ++i) {
+            if (node->children[i])
+                queryRayRecursive(node->children[i].get(), origin, dir, maxDist, out);
+        }
+    }
+
+    static void queryRadiusRecursive(const Node* node, Vec3 center,
+                                     f32 radius, std::vector<ECS::Entity>& out) {
+        Vec3 closest(
+            Math::clamp(center.x, node->bounds.min.x, node->bounds.max.x),
+            Math::clamp(center.y, node->bounds.min.y, node->bounds.max.y),
+            Math::clamp(center.z, node->bounds.min.z, node->bounds.max.z)
+        );
+        if ((center - closest).lengthSquared() > radius * radius)
+            return;
+
+        if (node->isLeaf) {
+            for (auto& e : node->entries) {
+                Vec3 ec(
+                    Math::clamp(center.x, e.bounds.min.x, e.bounds.max.x),
+                    Math::clamp(center.y, e.bounds.min.y, e.bounds.max.y),
+                    Math::clamp(center.z, e.bounds.min.z, e.bounds.max.z)
+                );
+                if ((center - ec).lengthSquared() <= radius * radius)
+                    out.push_back(e.entity);
+            }
+            return;
+        }
+
+        for (u32 i = 0; i < 8; ++i) {
+            if (node->children[i])
+                queryRadiusRecursive(node->children[i].get(), center, radius, out);
+        }
+    }
+
+    static u32 nodeCountRecursive(const Node* node) {
+        u32 count = 1;
+        if (!node->isLeaf) {
+            for (u32 i = 0; i < 8; ++i)
+                if (node->children[i])
+                    count += nodeCountRecursive(node->children[i].get());
+        }
+        return count;
+    }
+
+    static u32 entityCountRecursive(const Node* node) {
+        u32 count = (u32)node->entries.size();
+        if (!node->isLeaf) {
+            for (u32 i = 0; i < 8; ++i)
+                if (node->children[i])
+                    count += entityCountRecursive(node->children[i].get());
+        }
+        return count;
+    }
+
+    static u32 depthRecursive(const Node* node) {
+        if (node->isLeaf) return node->depth;
+        u32 md = 0;
+        for (u32 i = 0; i < 8; ++i)
+            if (node->children[i]) {
+                u32 cd = depthRecursive(node->children[i].get());
+                if (cd > md) md = cd;
+            }
+        return md;
+    }
+};
+
+} // namespace Caffeine::Spatial

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CAFFEINE_TEST_SOURCES
     test_animation.cpp
     test_mesh.cpp
     test_editor.cpp
+    test_octree.cpp
     test_pipeline.cpp
 )
 

--- a/tests/test_octree.cpp
+++ b/tests/test_octree.cpp
@@ -1,0 +1,342 @@
+#include "catch.hpp"
+#include "../src/Caffeine.hpp"
+
+#include <cmath>
+
+using namespace Caffeine;
+using namespace Caffeine::Spatial;
+using namespace Caffeine::ECS;
+
+static constexpr f32 kEps = 0.001f;
+
+// ============================================================================
+// AABB3D Tests
+// ============================================================================
+
+TEST_CASE("AABB3D - center and size", "[spatial][aabb]") {
+    AABB3D box{{0, 0, 0}, {4, 6, 8}};
+    Vec3 c = box.center();
+    REQUIRE(c.x == Approx(2.0f));
+    REQUIRE(c.y == Approx(3.0f));
+    REQUIRE(c.z == Approx(4.0f));
+
+    Vec3 s = box.size();
+    REQUIRE(s.x == Approx(4.0f));
+    REQUIRE(s.y == Approx(6.0f));
+    REQUIRE(s.z == Approx(8.0f));
+}
+
+TEST_CASE("AABB3D - contains point", "[spatial][aabb]") {
+    AABB3D box{{-2, -2, -2}, {2, 2, 2}};
+    REQUIRE(box.contains({0, 0, 0}));
+    REQUIRE(box.contains({2, 2, 2}));
+    REQUIRE(box.contains({-2, -2, -2}));
+    REQUIRE_FALSE(box.contains({3, 0, 0}));
+    REQUIRE_FALSE(box.contains({0, 5, 0}));
+    REQUIRE_FALSE(box.contains({0, 0, -3}));
+}
+
+TEST_CASE("AABB3D - contains AABB", "[spatial][aabb]") {
+    AABB3D outer{{-5, -5, -5}, {5, 5, 5}};
+    AABB3D inner{{-1, -1, -1}, {1, 1, 1}};
+    REQUIRE(outer.contains(inner));
+    REQUIRE_FALSE(inner.contains(outer));
+}
+
+TEST_CASE("AABB3D - intersects", "[spatial][aabb]") {
+    AABB3D a{{0, 0, 0}, {4, 4, 4}};
+    AABB3D overlapping{{2, 2, 2}, {6, 6, 6}};
+    AABB3D separate{{10, 10, 10}, {14, 14, 14}};
+    AABB3D touching{{4, 0, 0}, {8, 4, 4}};
+
+    REQUIRE(a.intersects(overlapping));
+    REQUIRE_FALSE(a.intersects(separate));
+    REQUIRE(a.intersects(touching));
+}
+
+TEST_CASE("AABB3D - intersectsRay", "[spatial][aabb]") {
+    AABB3D box{{-1, -1, -1}, {1, 1, 1}};
+
+    f32 t = -1.0f;
+    REQUIRE(box.intersectsRay({-5, 0, 0}, {1, 0, 0}, &t));
+    REQUIRE(t == Approx(4.0f));
+
+    REQUIRE_FALSE(box.intersectsRay({-5, 10, 0}, {1, 0, 0}));
+
+    REQUIRE(box.intersectsRay({0, 0, 0}, {1, 0, 0}, &t));
+    REQUIRE(t == Approx(0.0f));
+}
+
+// ============================================================================
+// Frustum Tests
+// ============================================================================
+
+TEST_CASE("Frustum - contains point", "[spatial][frustum]") {
+    f32 aspect = 16.0f / 9.0f;
+    Frustum f = Frustum::fromCamera(
+        {0, 0, -5}, {0, 0, 0}, {0, 1, 0},
+        Math::degToRad(60.0f), aspect, 0.1f, 100.0f
+    );
+
+    REQUIRE(f.contains({0, 0, 0}));
+    REQUIRE(f.contains({0, 0, -2}));
+    REQUIRE(f.contains({0, 0, 10}));
+    REQUIRE_FALSE(f.contains({0, 0, 200}));
+    REQUIRE_FALSE(f.contains({100, 0, 0}));
+}
+
+TEST_CASE("Frustum - intersects AABB", "[spatial][frustum]") {
+    f32 aspect = 16.0f / 9.0f;
+    Frustum f = Frustum::fromCamera(
+        {0, 0, -5}, {0, 0, 0}, {0, 1, 0},
+        Math::degToRad(60.0f), aspect, 0.1f, 100.0f
+    );
+
+    REQUIRE(f.intersects(AABB3D{{-1, -1, -1}, {1, 1, 1}}));
+    REQUIRE_FALSE(f.intersects(AABB3D{{-1, -1, 150}, {1, 1, 200}}));
+    REQUIRE(f.intersects(AABB3D{{-200, -200, -2}, {200, 200, 2}}));
+}
+
+TEST_CASE("Frustum - containsSphere", "[spatial][frustum]") {
+    f32 aspect = 16.0f / 9.0f;
+    Frustum f = Frustum::fromCamera(
+        {0, 0, -5}, {0, 0, 0}, {0, 1, 0},
+        Math::degToRad(60.0f), aspect, 0.1f, 100.0f
+    );
+
+    REQUIRE(f.containsSphere({0, 0, 0}, 1.0f));
+    REQUIRE_FALSE(f.containsSphere({0, 0, 200}, 10.0f));
+}
+
+// ============================================================================
+// Octree Tests
+// ============================================================================
+
+TEST_CASE("Octree - construction and empty queries", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}});
+    REQUIRE(octree.nodeCount() == 1);
+    REQUIRE(octree.entityCount() == 0);
+    REQUIRE(octree.depth() == 0);
+
+    std::vector<ECS::Entity> result;
+    octree.queryAABB({{-10, -10, -10}, {10, 10, 10}}, result);
+    REQUIRE(result.empty());
+
+    octree.queryFrustum(Frustum{}, result);
+    REQUIRE(result.empty());
+
+    octree.queryRay({0, 0, 0}, {1, 0, 0}, 100.0f, result);
+    REQUIRE(result.empty());
+
+    octree.queryRadius({0, 0, 0}, 10.0f, result);
+    REQUIRE(result.empty());
+}
+
+TEST_CASE("Octree - insert and entityCount", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e1(1, nullptr);
+    ECS::Entity e2(2, nullptr);
+    ECS::Entity e3(3, nullptr);
+
+    octree.insert(e1, {{-10, -10, -10}, {10, 10, 10}});
+    REQUIRE(octree.entityCount() == 1);
+
+    octree.insert(e2, {{20, 20, 20}, {30, 30, 30}});
+    REQUIRE(octree.entityCount() == 2);
+
+    octree.insert(e3, {{-50, -50, -50}, {-40, -40, -40}});
+    REQUIRE(octree.entityCount() == 3);
+}
+
+TEST_CASE("Octree - subdivision", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 4});
+
+    std::vector<ECS::Entity> entities;
+    for (u32 i = 0; i < 20; ++i) {
+        entities.emplace_back(i, nullptr);
+        f32 x = (f32)(i * 10) - 50.0f;
+        octree.insert(entities.back(), {{x - 2, -2, -2}, {x + 2, 2, 2}});
+    }
+
+    REQUIRE(octree.entityCount() == 20);
+    REQUIRE(octree.nodeCount() > 1);
+    REQUIRE(octree.depth() >= 1);
+}
+
+TEST_CASE("Octree - remove", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e1(1, nullptr);
+    ECS::Entity e2(2, nullptr);
+    octree.insert(e1, {{-5, -5, -5}, {5, 5, 5}});
+    octree.insert(e2, {{10, 10, 10}, {20, 20, 20}});
+    REQUIRE(octree.entityCount() == 2);
+
+    octree.remove(e1);
+    REQUIRE(octree.entityCount() == 1);
+
+    octree.remove(ECS::Entity(999, nullptr));
+    REQUIRE(octree.entityCount() == 1);
+}
+
+TEST_CASE("Octree - update", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e(1, nullptr);
+    octree.insert(e, {{-10, -10, -10}, {10, 10, 10}});
+    REQUIRE(octree.entityCount() == 1);
+
+    octree.update(e, {{50, 50, 50}, {60, 60, 60}});
+    REQUIRE(octree.entityCount() == 1);
+
+    std::vector<ECS::Entity> result;
+    octree.queryAABB({{-15, -15, -15}, {15, 15, 15}}, result);
+    REQUIRE(result.empty());
+
+    octree.queryAABB({{45, 45, 45}, {65, 65, 65}}, result);
+    REQUIRE(result.size() == 1);
+}
+
+TEST_CASE("Octree - queryAABB", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e1(1, nullptr);
+    ECS::Entity e2(2, nullptr);
+    octree.insert(e1, {{-2, -2, -2}, {2, 2, 2}});
+    octree.insert(e2, {{80, 80, 80}, {90, 90, 90}});
+
+    std::vector<ECS::Entity> result;
+    octree.queryAABB({{-5, -5, -5}, {5, 5, 5}}, result);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0] == e1);
+
+    result.clear();
+    octree.queryAABB({{70, 70, 70}, {95, 95, 95}}, result);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0] == e2);
+
+    result.clear();
+    octree.queryAABB({{-100, -100, -100}, {100, 100, 100}}, result);
+    REQUIRE(result.size() == 2);
+}
+
+TEST_CASE("Octree - queryAABB with subdivision", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 2, 4});
+
+    std::vector<ECS::Entity> entities;
+    for (u32 i = 0; i < 8; ++i) {
+        entities.emplace_back(i, nullptr);
+        f32 off = (f32)(i % 4) * 5.0f;
+        octree.insert(entities.back(), {{off, off, off}, {off + 2, off + 2, off + 2}});
+    }
+
+    std::vector<ECS::Entity> result;
+    octree.queryAABB({{-1, -1, -1}, {3, 3, 3}}, result);
+    REQUIRE(result.size() >= 1);
+    REQUIRE(octree.entityCount() == 8);
+    REQUIRE(octree.nodeCount() > 1);
+}
+
+TEST_CASE("Octree - queryFrustum", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e1(1, nullptr);
+    ECS::Entity e2(2, nullptr);
+    octree.insert(e1, {{-1, -1, -1}, {1, 1, 1}});
+    octree.insert(e2, {{-50, -50, 50}, {-40, -40, 60}});
+
+    f32 aspect = 16.0f / 9.0f;
+    Frustum frustum = Frustum::fromCamera(
+        {0, 0, -5}, {0, 0, 0}, {0, 1, 0},
+        Math::degToRad(60.0f), aspect, 0.1f, 100.0f
+    );
+
+    std::vector<ECS::Entity> result;
+    octree.queryFrustum(frustum, result);
+    REQUIRE(result.size() >= 1);
+}
+
+TEST_CASE("Octree - queryRadius", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e1(1, nullptr);
+    ECS::Entity e2(2, nullptr);
+    octree.insert(e1, {{-1, -1, -1}, {1, 1, 1}});
+    octree.insert(e2, {{80, 80, 80}, {90, 90, 90}});
+
+    std::vector<ECS::Entity> result;
+    octree.queryRadius({0, 0, 0}, 10.0f, result);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0] == e1);
+
+    result.clear();
+    octree.queryRadius({0, 0, 0}, 200.0f, result);
+    REQUIRE(result.size() == 2);
+}
+
+TEST_CASE("Octree - queryRay", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    ECS::Entity e1(1, nullptr);
+    octree.insert(e1, {{-1, -1, -1}, {1, 1, 1}});
+
+    std::vector<ECS::Entity> result;
+    octree.queryRay({-10, 0, 0}, {1, 0, 0}, 20.0f, result);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result[0] == e1);
+
+    result.clear();
+    octree.queryRay({10, 0, 0}, {1, 0, 0}, 20.0f, result);
+    REQUIRE(result.empty());
+}
+
+TEST_CASE("Octree - rebuild", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 4, 8});
+
+    std::vector<ECS::Entity> entities;
+    for (u32 i = 0; i < 10; ++i) {
+        entities.emplace_back(i, nullptr);
+        octree.insert(entities.back(), {{-1, -1, -1}, {1, 1, 1}});
+    }
+
+    REQUIRE(octree.entityCount() == 10);
+    u32 nodesBefore = octree.nodeCount();
+
+    octree.rebuild();
+    REQUIRE(octree.entityCount() == 10);
+    REQUIRE(octree.nodeCount() >= 1);
+}
+
+TEST_CASE("Octree - max depth prevents infinite subdivision", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 2, 0});
+
+    for (u32 i = 0; i < 100; ++i) {
+        ECS::Entity e(i, nullptr);
+        octree.insert(e, {{-1, -1, -1}, {1, 1, 1}});
+    }
+
+    REQUIRE(octree.nodeCount() == 1);
+    REQUIRE(octree.entityCount() == 100);
+}
+
+TEST_CASE("Octree - entityCount consistency after insert/remove", "[spatial][octree]") {
+    Octree octree({{{-100, -100, -100}, {100, 100, 100}}, 3, 4});
+
+    ECS::Entity entities[20];
+    for (u32 i = 0; i < 20; ++i) {
+        entities[i] = ECS::Entity(i, nullptr);
+        octree.insert(entities[i], {{-50 + (f32)i * 5, -1, -1}, {-48 + (f32)i * 5, 1, 1}});
+    }
+    REQUIRE(octree.entityCount() == 20);
+
+    for (u32 i = 0; i < 10; ++i) {
+        octree.remove(entities[i]);
+    }
+    REQUIRE(octree.entityCount() == 10);
+
+    for (u32 i = 10; i < 20; ++i) {
+        octree.remove(entities[i]);
+    }
+    REQUIRE(octree.entityCount() == 0);
+}


### PR DESCRIPTION
## Summary

- **AABB3D**: 3D axis-aligned bounding box with contains/intersects/intersectsRay (slab method)
- **Frustum**: Robust `fromCamera()` construction (works regardless of projection convention) + `fromMatrix()` for standard OpenGL-style VP matrices
- **Octree**: Spatial partitioning tree with insert/remove/update/rebuild, AABB/frustum/ray/radius queries, automatic subdivision, configurable depth limit
- Tests: 21 test cases with 75 assertions covering all spatial data structures
- Includes `Frustum::fromCamera()` as primary API — avoids compatibility issues with Caffeine's non-standard `Mat4::perspective()`

## Changes

| File | Description |
|------|-------------|
| `src/spatial/Octree.hpp` | AABB3D, Frustum, Octree implementation (~491 lines) |
| `tests/test_octree.cpp` | 21 test cases, 75 assertions |
| `src/Caffeine.hpp` | +1 include for spatial/Octree.hpp |
| `tests/CMakeLists.txt` | +1 test registration |
| `docs/fase5/spatial-partitioning.md` | Status → Implemented, updated API docs |

## Test Plan

- [x] All 545 tests pass (1,012,339 assertions)
- [x] Octree-specific tests: construction, empty queries, insert, remove, update, subdivision, rebuild, queryAABB, queryFrustum, queryRay, queryRadius, maxDepth limit, entityCount consistency

Closes RF5.4