### PR TITLE
feat(script): Lua scripting with sol2, hot-reload, and ECS integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(Caffeine VERSION 0.1.0 LANGUAGES CXX)
+project(Caffeine VERSION 0.1.0 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -89,3 +89,91 @@ target_include_directories(caf-encode PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_compile_features(caf-encode PRIVATE cxx_std_20)
 
 add_subdirectory(tests)
+
+# ── Scripting (Lua + sol2) ────────────────────────────────────
+option(CAFFEINE_ENABLE_SCRIPTING "Enable Lua scripting support" OFF)
+
+if(CAFFEINE_ENABLE_SCRIPTING)
+    include(FetchContent)
+
+    # Build Lua 5.4 from source (sol2 v3.3.0 needs exact 5.4 API)
+    FetchContent_Declare(lua54
+        GIT_REPOSITORY https://github.com/lua/lua.git
+        GIT_TAG v5.4.7
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_GetProperties(lua54)
+    if(NOT lua54_POPULATED)
+        FetchContent_Populate(lua54)
+        set(LUA54_SRC ${lua54_SOURCE_DIR})
+        add_library(lua54 STATIC
+            ${LUA54_SRC}/lapi.c
+            ${LUA54_SRC}/lauxlib.c
+            ${LUA54_SRC}/lbaselib.c
+            ${LUA54_SRC}/lcode.c
+            ${LUA54_SRC}/lcorolib.c
+            ${LUA54_SRC}/lctype.c
+            ${LUA54_SRC}/ldblib.c
+            ${LUA54_SRC}/ldebug.c
+            ${LUA54_SRC}/ldo.c
+            ${LUA54_SRC}/ldump.c
+            ${LUA54_SRC}/lfunc.c
+            ${LUA54_SRC}/lgc.c
+            ${LUA54_SRC}/linit.c
+            ${LUA54_SRC}/liolib.c
+            ${LUA54_SRC}/llex.c
+            ${LUA54_SRC}/lmathlib.c
+            ${LUA54_SRC}/lmem.c
+            ${LUA54_SRC}/loadlib.c
+            ${LUA54_SRC}/lobject.c
+            ${LUA54_SRC}/lopcodes.c
+            ${LUA54_SRC}/loslib.c
+            ${LUA54_SRC}/lparser.c
+            ${LUA54_SRC}/lstate.c
+            ${LUA54_SRC}/lstring.c
+            ${LUA54_SRC}/lstrlib.c
+            ${LUA54_SRC}/ltable.c
+            ${LUA54_SRC}/ltablib.c
+            ${LUA54_SRC}/ltm.c
+            ${LUA54_SRC}/lundump.c
+            ${LUA54_SRC}/lutf8lib.c
+            ${LUA54_SRC}/lvm.c
+            ${LUA54_SRC}/lzio.c
+        )
+        target_include_directories(lua54 BEFORE PUBLIC ${LUA54_SRC})
+        # Create lua.hpp C++ wrapper so sol2's #include <lua.hpp> finds our 5.4 headers
+        file(WRITE ${LUA54_SRC}/lua.hpp
+            "extern \"C\" {\n"
+            "#include \"lua.h\"\n"
+            "#include \"lauxlib.h\"\n"
+            "#include \"lualib.h\"\n"
+            "}\n")
+    endif()
+
+    # sol2 (header-only C++/Lua binding library)
+    set(SOL2_BUILD_LUA OFF)
+    FetchContent_Declare(sol2
+        GIT_REPOSITORY https://github.com/ThePhD/sol2.git
+        GIT_TAG v3.3.0
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(sol2)
+
+    # Patch sol2 optional_implementation.hpp for GCC 16+ compatibility
+    execute_process(COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_sol2_optional.py"
+        "${sol2_SOURCE_DIR}/include/sol/optional_implementation.hpp"
+        RESULT_VARIABLE PATCH_RESULT)
+    if(NOT PATCH_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to patch sol2 for GCC 16 compatibility")
+    endif()
+
+    target_link_libraries(Caffeine PRIVATE sol2::sol2 lua54)
+
+    target_compile_definitions(Caffeine PUBLIC CF_HAS_SCRIPTING=1)
+
+    target_sources(Caffeine PRIVATE
+        src/script/ScriptEngine.cpp
+        src/script/ScriptSystem.cpp
+        src/script/ScriptWatcher.cpp
+    )
+endif()

--- a/cmake/patch_sol2_optional.py
+++ b/cmake/patch_sol2_optional.py
@@ -1,0 +1,24 @@
+import sys
+
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+
+# Fix 1: optional_base<T> emplace -- this->construct() doesn't set this->m_value correctly
+content = content.replace(
+    '*this = nullopt;\n\t\t\tthis->construct(std::forward<Args>(args)...);\n\t\t\treturn value();',
+    '*this = nullopt;\n\t\t\tthis->m_value = std::addressof((std::forward<Args>(args), ...));\n\t\t\treturn value();')
+
+# Fix 2: optional<T&> emplace -- this->construct() doesn't exist in ref specialization
+content = content.replace(
+    '*this = nullopt;\n\t\t\tthis->construct(std::forward<Args>(args)...);\n\t\t}',
+    '*this = nullopt;\n\t\t\tm_value = std::addressof((std::forward<Args>(args), ...));\n\t\t\treturn *m_value;\n\t\t}')
+
+with open(path, 'w') as f:
+    f.write(content)
+
+remaining = content.count('this->construct(std::forward<Args>(args)')
+if remaining > 0:
+    print(f'WARNING: {remaining} unpatched occurrences remain')
+    sys.exit(1)
+print('sol2 optional_implementation.hpp patched')

--- a/src/Caffeine.hpp
+++ b/src/Caffeine.hpp
@@ -105,6 +105,14 @@
 #endif
 #endif
 
+// Scripting (optional — CAFFEINE_ENABLE_SCRIPTING)
+#ifdef CF_HAS_SCRIPTING
+#include "script/ScriptEngine.hpp"
+#include "script/ScriptTypes.hpp"
+#include "script/ScriptSystem.hpp"
+#include "script/ScriptWatcher.hpp"
+#endif
+
 // Tools (Asset Pipeline)
 #include "tools/PipelineTypes.hpp"
 #include "tools/TextureEncoder.hpp"

--- a/src/ecs/World.hpp
+++ b/src/ecs/World.hpp
@@ -283,4 +283,31 @@ void World::forEachParallel(const ComponentQuery& query, Threading::JobSystem& j
     barrier.wait();
 }
 
+template<typename T, typename... Args>
+T& Entity::add(Args&&... args) {
+    return m_world->add<T>(*this, std::forward<Args>(args)...);
+}
+
+template<typename T>
+void Entity::remove() {
+    m_world->remove<T>(*this);
+}
+
+template<typename T>
+bool Entity::has() const {
+    return m_world->has<T>(*this);
+}
+
+template<typename T>
+T* Entity::get() {
+    return m_world->get<T>(*this);
+}
+
+template<typename T>
+T& Entity::getOrAdd() {
+    T* ptr = m_world->get<T>(*this);
+    if (ptr) return *ptr;
+    return m_world->add<T>(*this);
+}
+
 }

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -130,6 +130,16 @@ AxisState InputManager::axisState(Axis axis) const {
     return state;
 }
 
+bool InputManager::isKeyDown(Key key) const {
+    auto idx = static_cast<usize>(key);
+    return idx < m_keyState.size() && m_keyState[idx];
+}
+
+bool InputManager::isMouseButtonDown(MouseButton button) const {
+    auto idx = static_cast<usize>(button);
+    return idx < m_mouseState.size() && m_mouseState[idx];
+}
+
 Vec2 InputManager::mousePosition() const {
     return m_mousePos;
 }

--- a/src/input/InputManager.hpp
+++ b/src/input/InputManager.hpp
@@ -185,6 +185,8 @@ public:
     // --- Query state ---
     ActionState actionState(Action action) const;
     AxisState   axisState(Axis axis) const;
+    bool        isKeyDown(Key key) const;
+    bool        isMouseButtonDown(MouseButton button) const;
     Vec2        mousePosition() const;
     Vec2        mouseDelta() const;
 

--- a/src/script/ScriptEngine.cpp
+++ b/src/script/ScriptEngine.cpp
@@ -1,0 +1,552 @@
+#include "script/ScriptEngine.hpp"
+#include "script/ScriptTypes.hpp"
+#include "ecs/World.hpp"
+#include "ecs/Components.hpp"
+#include "input/InputManager.hpp"
+#include "events/EventBus.hpp"
+#include "debug/LogSystem.hpp"
+#include "physics/PhysicsComponents2D.hpp"
+#include "containers/HashMap.hpp"
+#include "containers/Vector.hpp"
+
+#include <sol/sol.hpp>
+
+namespace Caffeine::Script {
+
+// ============================================================================
+// Internal implementation (Pimpl) — all sol2 types are here
+// ============================================================================
+
+struct ScriptEngine::Impl {
+    sol::state m_lua;
+
+    ECS::World* m_world = nullptr;
+    Input::InputManager* m_input = nullptr;
+    Events::EventBus* m_events = nullptr;
+
+    // Loaded scripts: virtualPath -> compiled chunk (as protected_function)
+    HashMap<std::string, sol::protected_function> m_scripts;
+
+    struct LuaEventEntry {
+        std::string eventName;
+        u32 id;
+        sol::protected_function callback;
+    };
+    Vector<LuaEventEntry> m_luaEvents;
+    u32 m_nextEventHandlerId = 1;
+};
+
+namespace {
+
+HashMap<std::string, Input::Key> makeKeyMap() {
+    HashMap<std::string, Input::Key> map;
+    map.set("Space", Input::Key::Space); map.set("Return", Input::Key::Return);
+    map.set("Escape", Input::Key::Escape); map.set("Backspace", Input::Key::Backspace);
+    map.set("Tab", Input::Key::Tab);
+    map.set("Up", Input::Key::Up); map.set("Down", Input::Key::Down);
+    map.set("Left", Input::Key::Left); map.set("Right", Input::Key::Right);
+    map.set("A", Input::Key::A); map.set("B", Input::Key::B);
+    map.set("C", Input::Key::C); map.set("D", Input::Key::D);
+    map.set("E", Input::Key::E); map.set("F", Input::Key::F);
+    map.set("G", Input::Key::G); map.set("H", Input::Key::H);
+    map.set("I", Input::Key::I); map.set("J", Input::Key::J);
+    map.set("K", Input::Key::K); map.set("L", Input::Key::L);
+    map.set("M", Input::Key::M); map.set("N", Input::Key::N);
+    map.set("O", Input::Key::O); map.set("P", Input::Key::P);
+    map.set("Q", Input::Key::Q); map.set("R", Input::Key::R);
+    map.set("S", Input::Key::S); map.set("T", Input::Key::T);
+    map.set("U", Input::Key::U); map.set("V", Input::Key::V);
+    map.set("W", Input::Key::W); map.set("X", Input::Key::X);
+    map.set("Y", Input::Key::Y); map.set("Z", Input::Key::Z);
+    map.set("0", Input::Key::Num0); map.set("1", Input::Key::Num1);
+    map.set("2", Input::Key::Num2); map.set("3", Input::Key::Num3);
+    map.set("4", Input::Key::Num4); map.set("5", Input::Key::Num5);
+    map.set("6", Input::Key::Num6); map.set("7", Input::Key::Num7);
+    map.set("8", Input::Key::Num8); map.set("9", Input::Key::Num9);
+    map.set("LShift", Input::Key::LShift); map.set("RShift", Input::Key::RShift);
+    map.set("LCtrl", Input::Key::LCtrl); map.set("RCtrl", Input::Key::RCtrl);
+    map.set("LAlt", Input::Key::LAlt); map.set("RAlt", Input::Key::RAlt);
+    return map;
+}
+
+HashMap<std::string, Input::Axis> makeAxisMap() {
+    HashMap<std::string, Input::Axis> map;
+    map.set("Horizontal", Input::Axis::MoveX);
+    map.set("Vertical", Input::Axis::MoveY);
+    map.set("LookX", Input::Axis::LookX);
+    map.set("LookY", Input::Axis::LookY);
+    return map;
+}
+
+// ============================================================================
+// Binding registration helpers
+// ============================================================================
+
+void registerWorldBindings(sol::state& lua, ECS::World* world) {
+    lua["caffeine"]["world"] = lua.create_table();
+    sol::table wt = lua["caffeine"]["world"];
+
+    wt["create"] = [world]() -> u32 {
+        ECS::Entity e = world->create("LuaEntity");
+        return e.id();
+    };
+
+    wt["destroy"] = [world](u32 entityId) {
+        world->destroy(ECS::Entity(entityId, world));
+    };
+
+    wt["hasComponent"] = [world](u32 entityId, const std::string& type) -> bool {
+        ECS::Entity e(entityId, world);
+        if (type == "Position2D") return e.has<ECS::Position2D>();
+        if (type == "Velocity2D") return e.has<ECS::Velocity2D>();
+        if (type == "Rotation")   return e.has<ECS::Rotation>();
+        if (type == "Scale2D")    return e.has<ECS::Scale2D>();
+        if (type == "Sprite")     return e.has<ECS::Sprite>();
+        if (type == "Health")     return e.has<ECS::Health>();
+        if (type == "RigidBody2D") return e.has<Physics2D::RigidBody2D>();
+        if (type == "Collider2D") return e.has<Physics2D::Collider2D>();
+        return false;
+    };
+
+    wt["getTransform"] = [&lua, world](u32 entityId) -> sol::table {
+        ECS::Entity e(entityId, world);
+        sol::table t = lua.create_table();
+        auto* pos = e.get<ECS::Position2D>();
+        auto* rot = e.get<ECS::Rotation>();
+        auto* scl = e.get<ECS::Scale2D>();
+        t["x"] = pos ? pos->x : 0.0f;
+        t["y"] = pos ? pos->y : 0.0f;
+        t["rotation"] = rot ? rot->angle : 0.0f;
+        t["scaleX"] = scl ? scl->x : 1.0f;
+        t["scaleY"] = scl ? scl->y : 1.0f;
+        return t;
+    };
+
+    wt["setTransform"] = [world](u32 entityId, sol::table t) {
+        ECS::Entity e(entityId, world);
+        auto& pos = e.getOrAdd<ECS::Position2D>();
+        pos.x = t["x"].get_or(0.0f);
+        pos.y = t["y"].get_or(0.0f);
+        auto& rot = e.getOrAdd<ECS::Rotation>();
+        rot.angle = t["rotation"].get_or(0.0f);
+        auto& scl = e.getOrAdd<ECS::Scale2D>();
+        scl.x = t["scaleX"].get_or(1.0f);
+        scl.y = t["scaleY"].get_or(1.0f);
+    };
+
+    wt["getVelocity"] = [&lua, world](u32 entityId) -> sol::table {
+        ECS::Entity e(entityId, world);
+        sol::table t = lua.create_table();
+        auto* v = e.get<ECS::Velocity2D>();
+        t["x"] = v ? v->x : 0.0f;
+        t["y"] = v ? v->y : 0.0f;
+        return t;
+    };
+
+    wt["setVelocity"] = [world](u32 entityId, sol::table t) {
+        ECS::Entity e(entityId, world);
+        auto& v = e.getOrAdd<ECS::Velocity2D>();
+        v.x = t["x"].get_or(0.0f);
+        v.y = t["y"].get_or(0.0f);
+    };
+
+    wt["getRigidBody2D"] = [&lua, world](u32 entityId) -> sol::table {
+        ECS::Entity e(entityId, world);
+        sol::table t = lua.create_table();
+        auto* rb = e.get<Physics2D::RigidBody2D>();
+        if (rb) {
+            t["mass"] = rb->mass;
+            t["restitution"] = rb->restitution;
+            t["friction"] = rb->friction;
+            t["linearDamping"] = rb->linearDamping;
+            t["isKinematic"] = rb->isKinematic;
+            t["lockRotation"] = rb->lockRotation;
+        }
+        return t;
+    };
+
+    wt["setRigidBody2D"] = [world](u32 entityId, sol::table t) {
+        ECS::Entity e(entityId, world);
+        auto& rb = e.getOrAdd<Physics2D::RigidBody2D>();
+        rb.mass = t["mass"].get_or(1.0f);
+        rb.restitution = t["restitution"].get_or(0.3f);
+        rb.friction = t["friction"].get_or(0.5f);
+        rb.linearDamping = t["linearDamping"].get_or(0.0f);
+        rb.isKinematic = t["isKinematic"].get_or(false);
+        rb.lockRotation = t["lockRotation"].get_or(true);
+    };
+
+    wt["getSprite"] = [&lua, world](u32 entityId) -> sol::table {
+        ECS::Entity e(entityId, world);
+        sol::table t = lua.create_table();
+        auto* s = e.get<ECS::Sprite>();
+        if (s) {
+            t["name"] = s->name;
+            t["frameIndex"] = s->frameIndex;
+        }
+        return t;
+    };
+
+    wt["setSprite"] = [world](u32 entityId, sol::table t) {
+        ECS::Entity e(entityId, world);
+        auto& s = e.getOrAdd<ECS::Sprite>();
+        s.name = t["name"].get_or(std::string());
+        s.frameIndex = t["frameIndex"].get_or(0u);
+    };
+}
+
+void registerInputBindings(sol::state& lua, Input::InputManager* input) {
+    // Build key/axis name mappings (static, built once)
+    static const HashMap<std::string, Input::Key> s_keyMap = makeKeyMap();
+    static const HashMap<std::string, Input::Axis> s_axisMap = makeAxisMap();
+
+    sol::table it = lua["caffeine"]["input"];
+
+    it["isKeyDown"] = [input](const std::string& keyName) -> bool {
+        auto* key = s_keyMap.get(keyName);
+        if (!key) return false;
+        return input->isKeyDown(*key);
+    };
+
+    it["getAxis"] = [input](const std::string& axisName) -> f32 {
+        auto* axis = s_axisMap.get(axisName);
+        if (!axis) return 0.0f;
+        return input->axisState(*axis).value;
+    };
+
+    it["mousePosition"] = [input]() -> std::pair<f32, f32> {
+        auto pos = input->mousePosition();
+        return {pos.x, pos.y};
+    };
+
+    it["isMouseButtonDown"] = [input](u32 btn) -> bool {
+        Input::MouseButton mb;
+        switch (btn) {
+            case 1:  mb = Input::MouseButton::Left; break;
+            case 2:  mb = Input::MouseButton::Middle; break;
+            case 3:  mb = Input::MouseButton::Right; break;
+            default: return false;
+        }
+        return input->isMouseButtonDown(mb);
+    };
+}
+
+void registerDebugBindings(sol::state& lua) {
+    sol::table dt = lua["caffeine"]["debug"];
+
+    dt["log"] = [](const std::string& msg) {
+        Debug::LogSystem::instance().log(
+            Debug::LogLevel::Info, "Lua", "%s", msg.c_str());
+    };
+
+    dt["warn"] = [](const std::string& msg) {
+        Debug::LogSystem::instance().log(
+            Debug::LogLevel::Warn, "Lua", "%s", msg.c_str());
+    };
+
+    dt["error"] = [](const std::string& msg) {
+        Debug::LogSystem::instance().log(
+            Debug::LogLevel::Error, "Lua", "%s", msg.c_str());
+    };
+}
+
+void registerMathBindings(sol::state& lua) {
+    sol::table mt = lua["caffeine"]["math"];
+
+    mt["vec2"] = [&lua](f32 x, f32 y) -> sol::table {
+        sol::table t = lua.create_table();
+        t["x"] = x;
+        t["y"] = y;
+        return t;
+    };
+
+    mt["add"] = [&lua](sol::table a, sol::table b) -> sol::table {
+        sol::table t = lua.create_table();
+        t["x"] = a["x"].get_or(0.0f) + b["x"].get_or(0.0f);
+        t["y"] = a["y"].get_or(0.0f) + b["y"].get_or(0.0f);
+        return t;
+    };
+
+    mt["sub"] = [&lua](sol::table a, sol::table b) -> sol::table {
+        sol::table t = lua.create_table();
+        t["x"] = a["x"].get_or(0.0f) - b["x"].get_or(0.0f);
+        t["y"] = a["y"].get_or(0.0f) - b["y"].get_or(0.0f);
+        return t;
+    };
+
+    mt["length"] = [](sol::table v) -> f32 {
+        f32 x = v["x"].get_or(0.0f);
+        f32 y = v["y"].get_or(0.0f);
+        return std::sqrt(x * x + y * y);
+    };
+
+    mt["normalize"] = [&lua](sol::table v) -> sol::table {
+        f32 x = v["x"].get_or(0.0f);
+        f32 y = v["y"].get_or(0.0f);
+        f32 len = std::sqrt(x * x + y * y);
+        sol::table t = lua.create_table();
+        if (len > 0.0001f) {
+            t["x"] = x / len;
+            t["y"] = y / len;
+        } else {
+            t["x"] = 0.0f;
+            t["y"] = 0.0f;
+        }
+        return t;
+    };
+
+    mt["dot"] = [](sol::table a, sol::table b) -> f32 {
+        return a["x"].get_or(0.0f) * b["x"].get_or(0.0f)
+             + a["y"].get_or(0.0f) * b["y"].get_or(0.0f);
+    };
+
+    mt["mul"] = [&lua](sol::table a, sol::table b) -> sol::table {
+        sol::table t = lua.create_table();
+        t["x"] = a["x"].get_or(0.0f) * b["x"].get_or(0.0f);
+        t["y"] = a["y"].get_or(0.0f) * b["y"].get_or(0.0f);
+        return t;
+    };
+
+    mt["scale"] = [&lua](sol::table v, f32 s) -> sol::table {
+        sol::table t = lua.create_table();
+        t["x"] = v["x"].get_or(0.0f) * s;
+        t["y"] = v["y"].get_or(0.0f) * s;
+        return t;
+    };
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// ScriptEngine implementation
+// ============================================================================
+
+ScriptEngine::ScriptEngine()
+    : m_impl(std::make_unique<Impl>()) {}
+
+ScriptEngine::~ScriptEngine() = default;
+
+bool ScriptEngine::init(const InitParams& params) {
+    m_impl->m_world = params.world;
+    m_impl->m_input = params.input;
+    m_impl->m_events = params.events;
+
+    auto& lua = m_impl->m_lua;
+
+    // Open only safe libraries
+    lua.open_libraries(
+        sol::lib::base,
+        sol::lib::math,
+        sol::lib::string,
+        sol::lib::table
+    );
+
+    // Override print to route through log system
+    lua["print"] = [](sol::this_state s, sol::variadic_args args) {
+        lua_State* L = s;
+        std::string msg;
+        for (auto v : args) {
+            if (!msg.empty()) msg += "\t";
+            v.push();
+            size_t len;
+            const char* str = luaL_tolstring(L, -1, &len);
+            if (str) {
+                msg.append(str, len);
+                lua_pop(L, 1);
+            }
+        }
+        Debug::LogSystem::instance().log(
+            Debug::LogLevel::Info, "Lua", "%s", msg.c_str());
+    };
+
+    // Create root caffeine table + all sub-tables
+    lua["caffeine"] = lua.create_table();
+    lua["caffeine"]["world"] = lua.create_table();
+    lua["caffeine"]["input"] = lua.create_table();
+    lua["caffeine"]["events"] = lua.create_table();
+    lua["caffeine"]["debug"] = lua.create_table();
+    lua["caffeine"]["math"]  = lua.create_table();
+
+    registerWorldBindings(lua, m_impl->m_world);
+    registerInputBindings(lua, m_impl->m_input);
+
+    // Event bindings (inline: needs access to Impl internals)
+    {
+        sol::table et = lua["caffeine"]["events"];
+        auto* impl = m_impl.get();
+
+        et["on"] = [impl](const std::string& eventName,
+                          sol::protected_function callback) -> u32 {
+            u32 handle = impl->m_nextEventHandlerId++;
+            impl->m_luaEvents.pushBack(
+                {eventName, handle, std::move(callback)});
+            return handle;
+        };
+
+        et["emit"] = [impl](const std::string& eventName,
+                            sol::variadic_args args) {
+            for (usize i = 0; i < impl->m_luaEvents.size(); ++i) {
+                auto& entry = impl->m_luaEvents[i];
+                if (entry.eventName != eventName) continue;
+                auto result = entry.callback(args);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    CF_ERROR("Lua", "Event '%s' handler error: %s",
+                             eventName.c_str(), err.what());
+                }
+            }
+        };
+
+        et["off"] = [impl](u32 handle) {
+            for (usize i = 0; i < impl->m_luaEvents.size(); ++i) {
+                if (impl->m_luaEvents[i].id != handle) continue;
+                if (i < impl->m_luaEvents.size() - 1) {
+                    impl->m_luaEvents[i] = impl->m_luaEvents.back();
+                }
+                impl->m_luaEvents.popBack();
+                return;
+            }
+        };
+    }
+
+    registerDebugBindings(lua);
+    registerMathBindings(lua);
+
+    // Sandboxing: block dangerous globals
+    lua["dofile"] = sol::nil;
+    lua["load"] = sol::nil;
+    lua["loadfile"] = sol::nil;
+
+    return true;
+}
+
+void ScriptEngine::shutdown() {
+    m_impl->m_lua.collect_garbage();
+    m_impl->m_scripts.clear();
+    m_impl->m_luaEvents.clear();
+}
+
+bool ScriptEngine::loadScript(const std::string& path, std::string* outError) {
+    auto& lua = m_impl->m_lua;
+
+    auto result = lua.load_file(path);
+    if (!result.valid()) {
+        sol::error err = result;
+        if (outError) *outError = err.what();
+        CF_ERROR("Script", "Failed to load %s: %s", path.c_str(), err.what());
+        return false;
+    }
+
+    // Execute the chunk to register global functions (onCreate, onUpdate, etc.)
+    sol::protected_function chunk = result;
+    auto execResult = chunk();
+    if (!execResult.valid()) {
+        sol::error err = execResult;
+        if (outError) *outError = err.what();
+        CF_ERROR("Script", "Failed to execute %s: %s", path.c_str(), err.what());
+        return false;
+    }
+
+    // Store the chunk for potential hot-reload
+    m_impl->m_scripts.set(path, chunk);
+    CF_INFO("Script", "Loaded script: %s", path.c_str());
+    return true;
+}
+
+bool ScriptEngine::loadString(const std::string& code,
+                              const std::string& virtualPath,
+                              std::string* outError) {
+    auto& lua = m_impl->m_lua;
+
+    auto result = lua.load(code, virtualPath);
+    if (!result.valid()) {
+        sol::error err = result;
+        if (outError) *outError = err.what();
+        return false;
+    }
+
+    sol::protected_function chunk = result;
+    auto execResult = chunk();
+    if (!execResult.valid()) {
+        sol::error err = execResult;
+        if (outError) *outError = err.what();
+        return false;
+    }
+
+    m_impl->m_scripts.set(virtualPath, chunk);
+    return true;
+}
+
+bool ScriptEngine::reloadScript(const std::string& path, std::string* outError) {
+    // Re-load from disk — overwrites the stored chunk
+    return loadScript(path, outError);
+}
+
+bool ScriptEngine::isLoaded(const std::string& path) const {
+    return m_impl->m_scripts.get(path) != nullptr;
+}
+
+bool ScriptEngine::callOnCreate(const std::string& path, ECS::Entity entity) {
+    (void)path;
+    auto& lua = m_impl->m_lua;
+    sol::protected_function fn = lua["onCreate"];
+    if (!fn.valid()) return false;
+
+    auto result = fn(static_cast<u32>(entity.id()));
+    if (!result.valid()) {
+        sol::error err = result;
+        CF_ERROR("Lua", "onCreate error: %s", err.what());
+        return false;
+    }
+    return true;
+}
+
+bool ScriptEngine::callOnUpdate(const std::string& path, ECS::Entity entity,
+                                 f32 dt) {
+    (void)path;
+    auto& lua = m_impl->m_lua;
+    sol::protected_function fn = lua["onUpdate"];
+    if (!fn.valid()) return false;
+
+    auto result = fn(static_cast<u32>(entity.id()), dt);
+    if (!result.valid()) {
+        sol::error err = result;
+        CF_ERROR("Lua", "onUpdate error: %s", err.what());
+        return false;
+    }
+    return true;
+}
+
+bool ScriptEngine::callOnDestroy(const std::string& path, ECS::Entity entity) {
+    (void)path;
+    auto& lua = m_impl->m_lua;
+    sol::protected_function fn = lua["onDestroy"];
+    if (!fn.valid()) return false;
+
+    auto result = fn(static_cast<u32>(entity.id()));
+    if (!result.valid()) {
+        sol::error err = result;
+        CF_ERROR("Lua", "onDestroy error: %s", err.what());
+        return false;
+    }
+    return true;
+}
+
+bool ScriptEngine::callOnCollision(const std::string& path, ECS::Entity entity,
+                                    ECS::Entity other) {
+    (void)path;
+    auto& lua = m_impl->m_lua;
+    sol::protected_function fn = lua["onCollision"];
+    if (!fn.valid()) return false;
+
+    auto result = fn(static_cast<u32>(entity.id()),
+                     static_cast<u32>(other.id()));
+    if (!result.valid()) {
+        sol::error err = result;
+        CF_ERROR("Lua", "onCollision error: %s", err.what());
+        return false;
+    }
+    return true;
+}
+
+} // namespace Caffeine::Script

--- a/src/script/ScriptEngine.hpp
+++ b/src/script/ScriptEngine.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "ecs/Entity.hpp"
+
+#include <memory>
+#include <string>
+
+namespace Caffeine { namespace Input { class InputManager; } }
+namespace Caffeine { namespace Events { class EventBus; } }
+
+namespace Caffeine::Script {
+
+class ScriptEngine {
+public:
+    ScriptEngine();
+    ~ScriptEngine();
+
+    ScriptEngine(const ScriptEngine&) = delete;
+    ScriptEngine& operator=(const ScriptEngine&) = delete;
+
+    struct InitParams {
+        ECS::World* world = nullptr;
+        Input::InputManager* input = nullptr;
+        Events::EventBus* events = nullptr;
+    };
+
+    bool init(const InitParams& params);
+    void shutdown();
+
+    bool loadScript(const std::string& path, std::string* outError = nullptr);
+    bool loadString(const std::string& code, const std::string& virtualPath,
+                    std::string* outError = nullptr);
+    bool reloadScript(const std::string& path, std::string* outError = nullptr);
+    bool isLoaded(const std::string& path) const;
+
+    // Lifecycle calls
+    bool callOnCreate(const std::string& path, ECS::Entity entity);
+    bool callOnUpdate(const std::string& path, ECS::Entity entity, f32 dt);
+    bool callOnDestroy(const std::string& path, ECS::Entity entity);
+    bool callOnCollision(const std::string& path, ECS::Entity entity,
+                         ECS::Entity other);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+
+    void registerBindings();
+};
+
+} // namespace Caffeine::Script

--- a/src/script/ScriptSystem.cpp
+++ b/src/script/ScriptSystem.cpp
@@ -1,0 +1,71 @@
+#include "script/ScriptSystem.hpp"
+#include "script/ScriptTypes.hpp"
+#include "ecs/World.hpp"
+#include "ecs/ComponentQuery.hpp"
+#include "debug/LogSystem.hpp"
+
+namespace Caffeine::Script {
+
+ScriptSystem::ScriptSystem(ScriptEngine* engine)
+    : m_engine(engine) {}
+
+void ScriptSystem::onUpdate(ECS::World& world, f32 dt) {
+    if (!m_engine) return;
+
+    ECS::ComponentQuery q;
+    q.with<ScriptComponent>();
+
+    // Phase 1: Collect entity data without processing scripts.
+    // We must NOT call callOnCreate/callOnUpdate during forEach because those
+    // can add components (e.g., Position2D via setTransform), triggering
+    // archetype migration via World::add. This invalidates forEach's iteration
+    // state (cached entityCount becomes stale, out-of-bounds access → SIGSEGV).
+    struct ScriptEntry {
+        u32 entityId;
+        std::string scriptPath;
+    };
+    Vector<ScriptEntry> entries;
+
+    world.forEach<ScriptComponent>(q,
+        [&entries](ECS::Entity entity, ScriptComponent& sc) {
+            if (sc.scriptPath.empty()) return;
+            entries.pushBack({entity.id(), sc.scriptPath});
+        });
+
+    // Phase 2: Process each entity outside forEach, safe to modify archetypes.
+    for (auto& entry : entries) {
+        ECS::Entity entity(entry.entityId, &world);
+        if (!entity.isValid()) continue;
+
+        const std::string& path = entry.scriptPath;
+
+        // Load script if not yet loaded
+        if (!m_engine->isLoaded(path)) {
+            std::string err;
+            if (!m_engine->loadScript(path, &err)) {
+                CF_ERROR("Script", "Failed to load %s: %s",
+                         path.c_str(), err.c_str());
+                continue;
+            }
+        }
+
+        // First encounter: call onCreate
+        bool isNew = true;
+        for (usize i = 0; i < m_initialized.size(); ++i) {
+            if (m_initialized[i].id() == entity.id()) {
+                isNew = false;
+                break;
+            }
+        }
+
+        if (isNew) {
+            m_engine->callOnCreate(path, entity);
+            m_initialized.pushBack(entity);
+        }
+
+        // Per-frame update
+        m_engine->callOnUpdate(path, entity, dt);
+    }
+}
+
+} // namespace Caffeine::Script

--- a/src/script/ScriptSystem.hpp
+++ b/src/script/ScriptSystem.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "ecs/ISystem.hpp"
+#include "ecs/Entity.hpp"
+#include "containers/Vector.hpp"
+#include "script/ScriptEngine.hpp"
+
+namespace Caffeine::Script {
+
+class ScriptSystem : public ECS::ISystem {
+public:
+    explicit ScriptSystem(ScriptEngine* engine);
+
+    void onUpdate(ECS::World& world, f32 dt) override;
+
+private:
+    ScriptEngine* m_engine;
+    Vector<ECS::Entity> m_initialized;
+};
+
+} // namespace Caffeine::Script

--- a/src/script/ScriptTypes.hpp
+++ b/src/script/ScriptTypes.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "core/Types.hpp"
+
+#include <string>
+
+namespace Caffeine::Script {
+
+struct ScriptComponent {
+    std::string scriptPath;
+};
+
+} // namespace Caffeine::Script

--- a/src/script/ScriptWatcher.cpp
+++ b/src/script/ScriptWatcher.cpp
@@ -1,0 +1,66 @@
+#include "script/ScriptWatcher.hpp"
+#include "debug/LogSystem.hpp"
+
+#include <system_error>
+
+namespace Caffeine::Script {
+
+void ScriptWatcher::init(ScriptEngine* engine, std::string_view scriptsDir) {
+    m_engine = engine;
+    m_dir = scriptsDir;
+    if (m_dir.empty()) return;
+
+    std::error_code ec;
+    for (auto& entry : std::filesystem::recursive_directory_iterator(m_dir, ec)) {
+        if (entry.path().extension() != ".lua") continue;
+        auto mtime = std::filesystem::last_write_time(entry.path(), ec);
+        if (ec) continue;
+        m_mtimes.set(entry.path().string(), mtime);
+    }
+
+    if (ec) {
+        CF_WARN("ScriptWatcher", "Error scanning scripts directory: %s", ec.message().c_str());
+    }
+    CF_INFO("ScriptWatcher", "Watching %s for script changes", m_dir.c_str());
+}
+
+void ScriptWatcher::shutdown() {
+    m_mtimes.clear();
+    m_engine = nullptr;
+    m_dir.clear();
+}
+
+void ScriptWatcher::poll() {
+    if (!m_engine || m_dir.empty()) return;
+
+    std::error_code ec;
+    for (auto& entry : std::filesystem::recursive_directory_iterator(m_dir, ec)) {
+        if (entry.path().extension() != ".lua") continue;
+
+        auto pathStr = entry.path().string();
+        auto currentMtime = std::filesystem::last_write_time(entry.path(), ec);
+        if (ec) continue;
+
+        auto* storedMtime = m_mtimes.get(pathStr);
+        if (!storedMtime) {
+            m_mtimes.set(pathStr, currentMtime);
+            continue;
+        }
+
+        if (currentMtime != *storedMtime) {
+            m_mtimes.set(pathStr, currentMtime);
+            std::string err;
+            if (!m_engine->reloadScript(pathStr, &err)) {
+                CF_ERROR("ScriptWatcher", "Failed to reload %s: %s", pathStr.c_str(), err.c_str());
+            } else {
+                CF_INFO("ScriptWatcher", "Hot-reloaded %s", pathStr.c_str());
+            }
+        }
+    }
+
+    if (ec) {
+        CF_WARN("ScriptWatcher", "Error polling scripts directory: %s", ec.message().c_str());
+    }
+}
+
+} // namespace Caffeine::Script

--- a/src/script/ScriptWatcher.hpp
+++ b/src/script/ScriptWatcher.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "containers/HashMap.hpp"
+#include "script/ScriptEngine.hpp"
+
+#include <string>
+#include <filesystem>
+
+namespace Caffeine::Script {
+
+class ScriptWatcher {
+public:
+    void init(ScriptEngine* engine, std::string_view scriptsDir);
+    void shutdown();
+    void poll();
+
+private:
+    ScriptEngine* m_engine = nullptr;
+    std::string m_dir;
+    HashMap<std::string, std::filesystem::file_time_type> m_mtimes;
+};
+
+} // namespace Caffeine::Script

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,10 @@ endif()
 enable_testing()
 add_test(NAME CaffeineTest COMMAND CaffeineTest)
 
+if(CAFFEINE_ENABLE_SCRIPTING)
+    list(APPEND CAFFEINE_TEST_SOURCES test_script.cpp)
+endif()
+
 if(SDL3_FOUND AND WIN32)
     add_custom_command(TARGET CaffeineTest POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -1,0 +1,509 @@
+#include "catch.hpp"
+
+#ifdef CF_HAS_SCRIPTING
+
+#include "../src/script/ScriptEngine.hpp"
+#include "../src/script/ScriptSystem.hpp"
+#include "../src/script/ScriptTypes.hpp"
+#include "../src/ecs/World.hpp"
+#include "../src/ecs/Components.hpp"
+#include "../src/input/InputManager.hpp"
+#include "../src/events/EventBus.hpp"
+#include "../src/debug/LogSystem.hpp"
+
+#include <string>
+
+using namespace Caffeine;
+using namespace Caffeine::Script;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+struct ScriptTestFixture {
+    ECS::World world;
+    Input::InputManager input;
+    Events::EventBus events;
+    ScriptEngine engine;
+
+    ScriptTestFixture() {
+        engine.init({&world, &input, &events});
+    }
+
+    ScriptTestFixture(const ScriptTestFixture&) = delete;
+    ScriptTestFixture& operator=(const ScriptTestFixture&) = delete;
+
+    ~ScriptTestFixture() {
+        engine.shutdown();
+    }
+
+    ECS::Entity createEntity(const char* scriptPath) {
+        auto e = world.create("TestEntity");
+        ScriptComponent sc;
+        sc.scriptPath = scriptPath;
+        e.add<ScriptComponent>(std::move(sc));
+        return e;
+    }
+};
+
+// ============================================================================
+// 1. ScriptEngine init/shutdown
+// ============================================================================
+
+TEST_CASE("ScriptEngine init and shutdown", "[script]") {
+    ECS::World world;
+    Input::InputManager input;
+    Events::EventBus events;
+    ScriptEngine engine;
+
+    REQUIRE(engine.init({&world, &input, &events}));
+    // shutdown in destructor
+}
+
+// ============================================================================
+// 2. loadString stores script and isLoaded reflects it
+// ============================================================================
+
+TEST_CASE("loadString marks script as loaded", "[script]") {
+    ScriptTestFixture fix;
+
+    REQUIRE(fix.engine.loadString("function onCreate(eid) end", "test.lua"));
+    REQUIRE(fix.engine.isLoaded("test.lua"));
+    REQUIRE_FALSE(fix.engine.isLoaded("nonexistent.lua"));
+}
+
+// ============================================================================
+// 3. callOnCreate receives correct entity ID — positions via world binding
+// ============================================================================
+
+TEST_CASE("callOnCreate moves entity via world transform binding", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 42.5, y = 99.5, rotation = 1.5, scaleX = 2.0, scaleY = 3.0})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "create_test.lua"));
+
+    auto entity = fix.world.create("Test");
+    REQUIRE(fix.engine.callOnCreate("create_test.lua", entity));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(42.5f));
+    REQUIRE(pos->y == Approx(99.5f));
+
+    auto* rot = entity.get<ECS::Rotation>();
+    REQUIRE(rot != nullptr);
+    REQUIRE(rot->angle == Approx(1.5f));
+}
+
+// ============================================================================
+// 4. callOnUpdate receives dt
+// ============================================================================
+
+TEST_CASE("callOnUpdate receives correct delta time", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid) end
+        function onUpdate(eid, dt)
+            local t = caffeine.world.getTransform(eid)
+            caffeine.world.setTransform(eid, {x = t.x + dt, y = t.y + dt})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "update_test.lua"));
+
+    auto entity = fix.world.create("Test");
+    entity.add<ECS::Position2D>(ECS::Position2D{10.0f, 20.0f});
+
+    REQUIRE(fix.engine.callOnCreate("update_test.lua", entity));
+
+    REQUIRE(fix.engine.callOnUpdate("update_test.lua", entity, 3.0f));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(13.0f));
+    REQUIRE(pos->y == Approx(23.0f));
+}
+
+// ============================================================================
+// 5. callOnDestroy fires without error
+// ============================================================================
+
+TEST_CASE("callOnDestroy fires cleanly", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onDestroy(eid)
+            -- cleanup: reset position to zero
+            caffeine.world.setTransform(eid, {x = 0, y = 0})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "destroy_test.lua"));
+
+    auto entity = fix.world.create("Test");
+    entity.add<ECS::Position2D>(ECS::Position2D{100.0f, 200.0f});
+
+    REQUIRE(fix.engine.callOnDestroy("destroy_test.lua", entity));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(0.0f));
+    REQUIRE(pos->y == Approx(0.0f));
+}
+
+// ============================================================================
+// 6. ScriptSystem dispatches onCreate and onUpdate
+// ============================================================================
+
+TEST_CASE("ScriptSystem calls onCreate on first frame", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 77.0, y = 88.0})
+        end
+        function onUpdate(eid, dt) end
+    )";
+    REQUIRE(fix.engine.loadString(code, "sys_test.lua"));
+
+    auto entity = fix.createEntity("sys_test.lua");
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(77.0f));
+    REQUIRE(pos->y == Approx(88.0f));
+}
+
+TEST_CASE("ScriptSystem calls onUpdate every frame after onCreate", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 0, y = 0})
+        end
+        function onUpdate(eid, dt)
+            local t = caffeine.world.getTransform(eid)
+            caffeine.world.setTransform(eid, {x = t.x + 1, y = t.y + dt})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "sys_update.lua"));
+
+    auto entity = fix.createEntity("sys_update.lua");
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 1.0f); // frame 1: onCreate + onUpdate(1.0)
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(1.0f)); // 0 + 1
+    REQUIRE(pos->y == Approx(1.0f)); // 0 + 1.0
+
+    system.onUpdate(fix.world, 2.0f); // frame 2: onUpdate(2.0) only
+
+    REQUIRE(pos->x == Approx(2.0f)); // 1 + 1
+    REQUIRE(pos->y == Approx(3.0f)); // 1 + 2.0
+}
+
+// ============================================================================
+// 7. Input binding — isKeyDown
+// ============================================================================
+
+TEST_CASE("Input isKeyDown reflects injected key state", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onUpdate(eid, dt)
+            if caffeine.input.isKeyDown("Space") then
+                caffeine.world.setTransform(eid, {x = 1, y = 0})
+            else
+                caffeine.world.setTransform(eid, {x = 0, y = 0})
+            end
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "input_key.lua"));
+
+    auto entity = fix.createEntity("input_key.lua");
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f); // frame: key not pressed
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(0.0f));
+
+    fix.input.injectKeyDown(Input::Key::Space);
+    system.onUpdate(fix.world, 0.0f); // frame: Space pressed
+
+    REQUIRE(pos->x == Approx(1.0f));
+}
+
+// ============================================================================
+// 8. Input binding — getAxis
+// ============================================================================
+
+TEST_CASE("Input getAxis returns correct axis value", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onUpdate(eid, dt)
+            local h = caffeine.input.getAxis("Horizontal")
+            caffeine.world.setTransform(eid, {x = h, y = 0})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "input_axis.lua"));
+
+    auto entity = fix.createEntity("input_axis.lua");
+
+    // Bind axis: A = negative, D = positive
+    fix.input.bindAxis(Input::Axis::MoveX,
+                       Input::Binding::fromKey(Input::Key::A),
+                       Input::Binding::fromKey(Input::Key::D));
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f); // frame 1: axis is 0
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(0.0f));
+
+    fix.input.injectKeyDown(Input::Key::D);
+    system.onUpdate(fix.world, 0.0f); // frame 2: axis is +1
+
+    REQUIRE(pos->x == Approx(1.0f));
+}
+
+// ============================================================================
+// 9. Input binding — mousePosition
+// ============================================================================
+
+TEST_CASE("Input mousePosition returns correct coords", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onUpdate(eid, dt)
+            local mx, my = caffeine.input.mousePosition()
+            caffeine.world.setTransform(eid, {x = mx, y = my})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "input_mouse.lua"));
+
+    auto entity = fix.createEntity("input_mouse.lua");
+
+    fix.input.injectMouseMove(320.0f, 240.0f);
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(320.0f));
+    REQUIRE(pos->y == Approx(240.0f));
+}
+
+// ============================================================================
+// 10. Math binding — length and normalize
+// ============================================================================
+
+TEST_CASE("Math vec2 length and normalize work", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            local a = caffeine.math.vec2(3, 4)
+            local len = caffeine.math.length(a)
+            local n = caffeine.math.normalize(a)
+            caffeine.world.setTransform(eid, {x = len, y = n.x})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "math_len.lua"));
+
+    auto entity = fix.world.create("Test");
+    REQUIRE(fix.engine.callOnCreate("math_len.lua", entity));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(5.0f));   // length of (3,4)
+    REQUIRE(pos->y == Approx(3.0f / 5.0f)); // 0.6
+}
+
+// ============================================================================
+// 11. Math binding — add, sub, dot, scale
+// ============================================================================
+
+TEST_CASE("Math vec2 arithmetic operations work", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            local a = caffeine.math.vec2(10, 20)
+            local b = caffeine.math.vec2(3, 4)
+            local sum = caffeine.math.add(a, b)
+            local diff = caffeine.math.sub(a, b)
+            local d = caffeine.math.dot(a, b)
+            local s = caffeine.math.scale(a, 2)
+            caffeine.world.setTransform(eid, {x = sum.x, y = d})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "math_arith.lua"));
+
+    auto entity = fix.world.create("Test");
+    REQUIRE(fix.engine.callOnCreate("math_arith.lua", entity));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(13.0f));  // 10 + 3
+    REQUIRE(pos->y == Approx(10*3 + 20*4.0f)); // 110
+}
+
+// ============================================================================
+// 12. Sandbox — dangerous globals are blocked
+// ============================================================================
+
+TEST_CASE("Sandbox blocks dofile and load", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            -- dofile, load, loadfile should be nil
+            if dofile ~= nil then
+                caffeine.world.setTransform(eid, {x = 1, y = 0})
+            end
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "sandbox.lua"));
+
+    auto entity = fix.world.create("Test");
+    entity.add<ECS::Position2D>(ECS::Position2D{0.0f, 0.0f});
+
+    REQUIRE(fix.engine.callOnCreate("sandbox.lua", entity));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(0.0f)); // dofile was nil so transform wasn't set
+}
+
+// ============================================================================
+// 13. Lua error in lifecycle doesn't crash
+// ============================================================================
+
+TEST_CASE("Lua runtime error in callOnCreate doesn't crash", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            error("intentional crash test")
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "crash_test.lua"));
+
+    auto entity = fix.world.create("Test");
+    // Should return false but not crash
+    REQUIRE_FALSE(fix.engine.callOnCreate("crash_test.lua", entity));
+    // Engine is still usable after error
+    REQUIRE(fix.engine.loadString("function test() end", "still_works.lua"));
+}
+
+// ============================================================================
+// 14. Multiple entities with same script
+// ============================================================================
+
+TEST_CASE("Multiple entities with same script each get onCreate", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        counter = 0
+        function onCreate(eid)
+            counter = counter + 1
+            caffeine.world.setTransform(eid, {x = counter, y = 0})
+        end
+        function onUpdate(eid, dt) end
+    )";
+    REQUIRE(fix.engine.loadString(code, "multi.lua"));
+
+    auto e1 = fix.createEntity("multi.lua");
+    auto e2 = fix.createEntity("multi.lua");
+    auto e3 = fix.createEntity("multi.lua");
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+
+    auto* p1 = e1.get<ECS::Position2D>();
+    auto* p2 = e2.get<ECS::Position2D>();
+    auto* p3 = e3.get<ECS::Position2D>();
+    REQUIRE(p1 != nullptr);
+    REQUIRE(p2 != nullptr);
+    REQUIRE(p3 != nullptr);
+    REQUIRE(p1->x == Approx(1.0f));
+    REQUIRE(p2->x == Approx(2.0f));
+    REQUIRE(p3->x == Approx(3.0f));
+}
+
+// ============================================================================
+// 15. Event binding — on/emit/off (smoke test, observable via components)
+// ============================================================================
+
+TEST_CASE("Event on and emit trigger Lua callbacks", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.events.on("move", function(x, y)
+                caffeine.world.setTransform(eid, {x = x, y = y})
+            end)
+        end
+        function onUpdate(eid, dt)
+            caffeine.events.emit("move", dt, dt * 2)
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "event_test.lua"));
+
+    auto entity = fix.createEntity("event_test.lua");
+
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 10.0f); // onCreate + onUpdate -> emit(10, 20)
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(10.0f));
+    REQUIRE(pos->y == Approx(20.0f));
+}
+
+// ============================================================================
+// 16. Velocity bindings
+// ============================================================================
+
+TEST_CASE("World getVelocity and setVelocity work", "[script]") {
+    ScriptTestFixture fix;
+
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setVelocity(eid, {x = 5.0, y = 10.0})
+            local v = caffeine.world.getVelocity(eid)
+            caffeine.world.setTransform(eid, {x = v.x, y = v.y})
+        end
+    )";
+    REQUIRE(fix.engine.loadString(code, "vel_test.lua"));
+
+    auto entity = fix.world.create("Test");
+    REQUIRE(fix.engine.callOnCreate("vel_test.lua", entity));
+
+    auto* pos = entity.get<ECS::Position2D>();
+    REQUIRE(pos != nullptr);
+    REQUIRE(pos->x == Approx(5.0f));
+    REQUIRE(pos->y == Approx(10.0f));
+}
+
+#else // !CF_HAS_SCRIPTING
+
+TEST_CASE("Scripting disabled — placeholder", "[script]") {
+    // This file compiles to nothing when scripting is disabled
+    REQUIRE(true);
+}
+
+#endif // CF_HAS_SCRIPTING

--- a/tests/test_script_seq.cpp
+++ b/tests/test_script_seq.cpp
@@ -1,0 +1,629 @@
+/**
+ * @file test_script_seq.cpp
+ * @brief Standalone sequential test for ScriptEngine crash debugging
+ *
+ * Tests all scripting features sequentially in one process to catch
+ * cross-contamination or use-after-free bugs.
+ *
+ * Build:
+ *   g++ -std=c++20 -g -O0 -o test_script_seq tests/test_script_seq.cpp \
+ *       -Isrc -Ibuild/_deps/sol2-src/include \
+ *       -Ibuild/_deps/lua54-src/src \
+ *       build/libCaffeine.a build/liblua54.a \
+ *       -lm -ldl -lstdc++
+ *
+ * Or via CMake:
+ *   add_executable(script_seq tests/test_script_seq.cpp)
+ *   target_link_libraries(script_seq Caffeine lua54)
+ */
+
+#include "script/ScriptEngine.hpp"
+#include "script/ScriptSystem.hpp"
+#include "script/ScriptTypes.hpp"
+#include "ecs/World.hpp"
+#include "ecs/Components.hpp"
+#include "input/InputManager.hpp"
+#include "events/EventBus.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+using namespace Caffeine;
+using namespace Caffeine::Script;
+
+// ============================================================================
+// Test infrastructure
+// ============================================================================
+
+static int g_total = 0;
+static int g_passed = 0;
+static int g_failed = 0;
+
+#define TEST(name) \
+    do { \
+        g_total++; \
+        printf("  TEST %d: %s ... ", g_total, name); \
+        fflush(stdout); \
+        bool _ok = true;
+
+#define END_TEST(name) \
+        if (_ok) { \
+            printf("PASS\n"); \
+            g_passed++; \
+        } else { \
+            printf("FAIL\n"); \
+            g_failed++; \
+        } \
+    } while(0)
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        printf("\n    FAIL at %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        _ok = false; \
+    } \
+} while(0)
+
+#define CHECK_EQ(a, b) do { \
+    auto _a = (a); auto _b = (b); \
+    if (_a != _b) { \
+        printf("\n    FAIL at %s:%d: %s == %s  (got %lld, expected %lld)\n", \
+               __FILE__, __LINE__, #a, #b, (long long)_a, (long long)_b); \
+        _ok = false; \
+    } \
+} while(0)
+
+#define CHECK_APPROX(a, b, eps) do { \
+    auto _a = (a); auto _b = (b); \
+    if (std::abs(_a - _b) > (eps)) { \
+        printf("\n    FAIL at %s:%d: %s ≈ %s  (got %f, expected %f, eps %f)\n", \
+               __FILE__, __LINE__, #a, #b, (double)_a, (double)_b, (double)(eps)); \
+        _ok = false; \
+    } \
+} while(0)
+
+struct TestFixture {
+    ECS::World world;
+    Input::InputManager input;
+    Events::EventBus events;
+    ScriptEngine engine;
+
+    TestFixture() {
+        engine.init({&world, &input, &events});
+    }
+
+    TestFixture(const TestFixture&) = delete;
+    TestFixture& operator=(const TestFixture&) = delete;
+
+    ~TestFixture() {
+        engine.shutdown();
+    }
+
+    ECS::Entity createEntity(const char* scriptPath) {
+        auto e = world.create("TestEntity");
+        ScriptComponent sc;
+        sc.scriptPath = scriptPath;
+        e.add<ScriptComponent>(std::move(sc));
+        return e;
+    }
+};
+
+// ============================================================================
+// Test 1: init/shutdown
+// ============================================================================
+
+void testInitShutdown() {
+    TEST("ScriptEngine init and shutdown");
+    {
+        ECS::World w;
+        Input::InputManager in;
+        Events::EventBus ev;
+        ScriptEngine eng;
+        CHECK(eng.init({&w, &in, &ev}));
+    }
+    END_TEST("ScriptEngine init and shutdown");
+}
+
+// ============================================================================
+// Test 2: loadString
+// ============================================================================
+
+void testLoadString() {
+    TEST("loadString marks script as loaded");
+    TestFixture fix;
+    CHECK(fix.engine.loadString("function onCreate(eid) end", "test.lua"));
+    CHECK(fix.engine.isLoaded("test.lua"));
+    CHECK(!fix.engine.isLoaded("nonexistent.lua"));
+    END_TEST("loadString marks script as loaded");
+}
+
+// ============================================================================
+// Test 3: callOnCreate sets transform
+// ============================================================================
+
+void testCallOnCreateTransform() {
+    TEST("callOnCreate moves entity via world transform binding");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 42.5, y = 99.5, rotation = 1.5, scaleX = 2.0, scaleY = 3.0})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "create_test.lua"));
+    auto entity = fix.world.create("Test");
+    CHECK(fix.engine.callOnCreate("create_test.lua", entity));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 42.5f, 0.001f);
+    CHECK_APPROX(pos->y, 99.5f, 0.001f);
+    auto* rot = entity.get<ECS::Rotation>();
+    CHECK(rot != nullptr);
+    CHECK_APPROX(rot->angle, 1.5f, 0.001f);
+    END_TEST("callOnCreate moves entity via world transform binding");
+}
+
+// ============================================================================
+// Test 4: callOnUpdate with dt
+// ============================================================================
+
+void testCallOnUpdate() {
+    TEST("callOnUpdate receives correct delta time");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid) end
+        function onUpdate(eid, dt)
+            local t = caffeine.world.getTransform(eid)
+            caffeine.world.setTransform(eid, {x = t.x + dt, y = t.y + dt})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "update_test.lua"));
+    auto entity = fix.world.create("Test");
+    entity.add<ECS::Position2D>(ECS::Position2D{10.0f, 20.0f});
+    CHECK(fix.engine.callOnCreate("update_test.lua", entity));
+    CHECK(fix.engine.callOnUpdate("update_test.lua", entity, 3.0f));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 13.0f, 0.001f);
+    CHECK_APPROX(pos->y, 23.0f, 0.001f);
+    END_TEST("callOnUpdate receives correct delta time");
+}
+
+// ============================================================================
+// Test 5: callOnDestroy
+// ============================================================================
+
+void testCallOnDestroy() {
+    TEST("callOnDestroy fires cleanly");
+    TestFixture fix;
+    const char* code = R"(
+        function onDestroy(eid)
+            caffeine.world.setTransform(eid, {x = 0, y = 0})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "destroy_test.lua"));
+    auto entity = fix.world.create("Test");
+    entity.add<ECS::Position2D>(ECS::Position2D{100.0f, 200.0f});
+    CHECK(fix.engine.callOnDestroy("destroy_test.lua", entity));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 0.0f, 0.001f);
+    CHECK_APPROX(pos->y, 0.0f, 0.001f);
+    END_TEST("callOnDestroy fires cleanly");
+}
+
+// ============================================================================
+// Test 6: ScriptSystem onCreate
+// ============================================================================
+
+void testSystemOnCreate() {
+    TEST("ScriptSystem calls onCreate on first frame");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 77.0, y = 88.0})
+        end
+        function onUpdate(eid, dt) end
+    )";
+    CHECK(fix.engine.loadString(code, "sys_test.lua"));
+    auto entity = fix.createEntity("sys_test.lua");
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 77.0f, 0.001f);
+    CHECK_APPROX(pos->y, 88.0f, 0.001f);
+    END_TEST("ScriptSystem calls onCreate on first frame");
+}
+
+// ============================================================================
+// Test 7: ScriptSystem onUpdate
+// ============================================================================
+
+void testSystemOnUpdate() {
+    TEST("ScriptSystem calls onUpdate every frame after onCreate");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 0, y = 0})
+        end
+        function onUpdate(eid, dt)
+            local t = caffeine.world.getTransform(eid)
+            caffeine.world.setTransform(eid, {x = t.x + 1, y = t.y + dt})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "sys_update.lua"));
+    auto entity = fix.createEntity("sys_update.lua");
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 1.0f);
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 1.0f, 0.001f);
+    CHECK_APPROX(pos->y, 1.0f, 0.001f);
+    system.onUpdate(fix.world, 2.0f);
+    CHECK_APPROX(pos->x, 2.0f, 0.001f);
+    CHECK_APPROX(pos->y, 3.0f, 0.001f);
+    END_TEST("ScriptSystem calls onUpdate every frame after onCreate");
+}
+
+// ============================================================================
+// Test 8: Input isKeyDown
+// ============================================================================
+
+void testInputKeyDown() {
+    TEST("Input isKeyDown reflects injected key state");
+    TestFixture fix;
+    const char* code = R"(
+        function onUpdate(eid, dt)
+            if caffeine.input.isKeyDown("Space") then
+                caffeine.world.setTransform(eid, {x = 1, y = 0})
+            else
+                caffeine.world.setTransform(eid, {x = 0, y = 0})
+            end
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "input_key.lua"));
+    auto entity = fix.createEntity("input_key.lua");
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 0.0f, 0.001f);
+    fix.input.injectKeyDown(Input::Key::Space);
+    system.onUpdate(fix.world, 0.0f);
+    CHECK_APPROX(pos->x, 1.0f, 0.001f);
+    END_TEST("Input isKeyDown reflects injected key state");
+}
+
+// ============================================================================
+// Test 9: Input getAxis
+// ============================================================================
+
+void testInputAxis() {
+    TEST("Input getAxis returns correct axis value");
+    TestFixture fix;
+    const char* code = R"(
+        function onUpdate(eid, dt)
+            local h = caffeine.input.getAxis("Horizontal")
+            caffeine.world.setTransform(eid, {x = h, y = 0})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "input_axis.lua"));
+    auto entity = fix.createEntity("input_axis.lua");
+    fix.input.bindAxis(Input::Axis::MoveX,
+                       Input::Binding::fromKey(Input::Key::A),
+                       Input::Binding::fromKey(Input::Key::D));
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 0.0f, 0.001f);
+    fix.input.injectKeyDown(Input::Key::D);
+    system.onUpdate(fix.world, 0.0f);
+    CHECK_APPROX(pos->x, 1.0f, 0.001f);
+    END_TEST("Input getAxis returns correct axis value");
+}
+
+// ============================================================================
+// Test 10: Input mousePosition
+// ============================================================================
+
+void testInputMouse() {
+    TEST("Input mousePosition returns correct coords");
+    TestFixture fix;
+    const char* code = R"(
+        function onUpdate(eid, dt)
+            local mx, my = caffeine.input.mousePosition()
+            caffeine.world.setTransform(eid, {x = mx, y = my})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "input_mouse.lua"));
+    auto entity = fix.createEntity("input_mouse.lua");
+    fix.input.injectMouseMove(320.0f, 240.0f);
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 320.0f, 0.001f);
+    CHECK_APPROX(pos->y, 240.0f, 0.001f);
+    END_TEST("Input mousePosition returns correct coords");
+}
+
+// ============================================================================
+// Test 11: Math vec2 length/normalize
+// ============================================================================
+
+void testMathLength() {
+    TEST("Math vec2 length and normalize work");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            local a = caffeine.math.vec2(3, 4)
+            local len = caffeine.math.length(a)
+            local n = caffeine.math.normalize(a)
+            caffeine.world.setTransform(eid, {x = len, y = n.x})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "math_len.lua"));
+    auto entity = fix.world.create("Test");
+    CHECK(fix.engine.callOnCreate("math_len.lua", entity));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 5.0f, 0.001f);
+    CHECK_APPROX(pos->y, 3.0f/5.0f, 0.001f);
+    END_TEST("Math vec2 length and normalize work");
+}
+
+// ============================================================================
+// Test 12: Math vec2 arithmetic
+// ============================================================================
+
+void testMathArith() {
+    TEST("Math vec2 arithmetic operations work");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            local a = caffeine.math.vec2(10, 20)
+            local b = caffeine.math.vec2(3, 4)
+            local sum = caffeine.math.add(a, b)
+            local d = caffeine.math.dot(a, b)
+            caffeine.world.setTransform(eid, {x = sum.x, y = d})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "math_arith.lua"));
+    auto entity = fix.world.create("Test");
+    CHECK(fix.engine.callOnCreate("math_arith.lua", entity));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 13.0f, 0.001f);
+    CHECK_APPROX(pos->y, 10*3 + 20*4.0f, 0.001f);
+    END_TEST("Math vec2 arithmetic operations work");
+}
+
+// ============================================================================
+// Test 13: Sandbox
+// ============================================================================
+
+void testSandbox() {
+    TEST("Sandbox blocks dofile and load");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            if dofile ~= nil then
+                caffeine.world.setTransform(eid, {x = 1, y = 0})
+            end
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "sandbox.lua"));
+    auto entity = fix.world.create("Test");
+    entity.add<ECS::Position2D>(ECS::Position2D{0.0f, 0.0f});
+    CHECK(fix.engine.callOnCreate("sandbox.lua", entity));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 0.0f, 0.001f);
+    END_TEST("Sandbox blocks dofile and load");
+}
+
+// ============================================================================
+// Test 14: Lua error handling
+// ============================================================================
+
+void testErrorHandling() {
+    TEST("Lua runtime error in callOnCreate doesn't crash");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            error("intentional crash test")
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "crash_test.lua"));
+    auto entity = fix.world.create("Test");
+    CHECK(!fix.engine.callOnCreate("crash_test.lua", entity));
+    CHECK(fix.engine.loadString("function test() end", "still_works.lua"));
+    END_TEST("Lua runtime error in callOnCreate doesn't crash");
+}
+
+// ============================================================================
+// Test 15: Multiple entities with same script
+// ============================================================================
+
+void testMultiEntity() {
+    TEST("Multiple entities with same script each get onCreate");
+    TestFixture fix;
+    const char* code = R"(
+        counter = 0
+        function onCreate(eid)
+            counter = counter + 1
+            caffeine.world.setTransform(eid, {x = counter, y = 0})
+        end
+        function onUpdate(eid, dt) end
+    )";
+    CHECK(fix.engine.loadString(code, "multi.lua"));
+    auto e1 = fix.createEntity("multi.lua");
+    auto e2 = fix.createEntity("multi.lua");
+    auto e3 = fix.createEntity("multi.lua");
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 0.0f);
+    auto* p1 = e1.get<ECS::Position2D>();
+    auto* p2 = e2.get<ECS::Position2D>();
+    auto* p3 = e3.get<ECS::Position2D>();
+    CHECK(p1 != nullptr);
+    CHECK(p2 != nullptr);
+    CHECK(p3 != nullptr);
+    CHECK_APPROX(p1->x, 1.0f, 0.001f);
+    CHECK_APPROX(p2->x, 2.0f, 0.001f);
+    CHECK_APPROX(p3->x, 3.0f, 0.001f);
+    END_TEST("Multiple entities with same script each get onCreate");
+}
+
+// ============================================================================
+// Test 16: Event bindings
+// ============================================================================
+
+void testEvents() {
+    TEST("Event on and emit trigger Lua callbacks");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.events.on("move", function(x, y)
+                caffeine.world.setTransform(eid, {x = x, y = y})
+            end)
+        end
+        function onUpdate(eid, dt)
+            caffeine.events.emit("move", dt, dt * 2)
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "event_test.lua"));
+    auto entity = fix.createEntity("event_test.lua");
+    ScriptSystem system(&fix.engine);
+    system.onUpdate(fix.world, 10.0f);
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 10.0f, 0.001f);
+    CHECK_APPROX(pos->y, 20.0f, 0.001f);
+    END_TEST("Event on and emit trigger Lua callbacks");
+}
+
+// ============================================================================
+// Test 17: Velocity bindings
+// ============================================================================
+
+void testVelocity() {
+    TEST("World getVelocity and setVelocity work");
+    TestFixture fix;
+    const char* code = R"(
+        function onCreate(eid)
+            caffeine.world.setVelocity(eid, {x = 5.0, y = 10.0})
+            local v = caffeine.world.getVelocity(eid)
+            caffeine.world.setTransform(eid, {x = v.x, y = v.y})
+        end
+    )";
+    CHECK(fix.engine.loadString(code, "vel_test.lua"));
+    auto entity = fix.world.create("Test");
+    CHECK(fix.engine.callOnCreate("vel_test.lua", entity));
+    auto* pos = entity.get<ECS::Position2D>();
+    CHECK(pos != nullptr);
+    CHECK_APPROX(pos->x, 5.0f, 0.001f);
+    CHECK_APPROX(pos->y, 10.0f, 0.001f);
+    END_TEST("World getVelocity and setVelocity work");
+}
+
+// ============================================================================
+// Test 18: Isolated init/shutdown cycle (stress test)
+// ============================================================================
+
+void testRepeatedInit() {
+    TEST("Multiple init/shutdown cycles");
+    for (int i = 0; i < 5; i++) {
+        ECS::World w;
+        Input::InputManager in;
+        Events::EventBus ev;
+        ScriptEngine eng;
+        CHECK(eng.init({&w, &in, &ev}));
+        CHECK(eng.loadString("function onCreate(eid) end", "a.lua"));
+        CHECK(eng.isLoaded("a.lua"));
+        auto entity = w.create("Test");
+        CHECK(eng.callOnCreate("a.lua", entity));
+    }
+    END_TEST("Multiple init/shutdown cycles");
+}
+
+// ============================================================================
+// Test 19: Interleaved script engines
+// ============================================================================
+
+void testInterleavedEngines() {
+    TEST("Two engines active simultaneously with different scripts");
+    ECS::World w1, w2;
+    Input::InputManager in1, in2;
+    Events::EventBus ev1, ev2;
+    ScriptEngine eng1, eng2;
+
+    CHECK(eng1.init({&w1, &in1, &ev1}));
+    CHECK(eng2.init({&w2, &in2, &ev2}));
+
+    const char* code1 = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 111, y = 222})
+        end
+    )";
+    const char* code2 = R"(
+        function onCreate(eid)
+            caffeine.world.setTransform(eid, {x = 333, y = 444})
+        end
+    )";
+
+    CHECK(eng1.loadString(code1, "eng1.lua"));
+    CHECK(eng2.loadString(code2, "eng2.lua"));
+
+    auto e1 = w1.create("E1");
+    auto e2 = w2.create("E2");
+
+    CHECK(eng1.callOnCreate("eng1.lua", e1));
+    CHECK(eng2.callOnCreate("eng2.lua", e2));
+
+    auto* p1 = e1.get<ECS::Position2D>();
+    auto* p2 = e2.get<ECS::Position2D>();
+    CHECK(p1 != nullptr);
+    CHECK(p2 != nullptr);
+    CHECK_APPROX(p1->x, 111.0f, 0.001f);
+    CHECK_APPROX(p2->x, 333.0f, 0.001f);
+
+    eng1.shutdown();
+    eng2.shutdown();
+    END_TEST("Two engines active simultaneously with different scripts");
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main() {
+    printf("ScriptEngine Sequential Test Suite\n");
+    printf("==================================\n\n");
+
+    testInitShutdown();
+    testLoadString();
+    testCallOnCreateTransform();
+    testCallOnUpdate();
+    testCallOnDestroy();
+    testSystemOnCreate();
+    testSystemOnUpdate();
+    testInputKeyDown();
+    testInputAxis();
+    testInputMouse();
+    testMathLength();
+    testMathArith();
+    testSandbox();
+    testErrorHandling();
+    testMultiEntity();
+    testEvents();
+    testVelocity();
+    testRepeatedInit();
+    testInterleavedEngines();
+
+    printf("\n==================================\n");
+    printf("Results: %d passed, %d failed, %d total\n",
+           g_passed, g_failed, g_total);
+
+    return g_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Lua 5.4 + sol2 v3.3.0 scripting engine with ECS integration
- Pimpl pattern hides all `sol::` types from public headers
- ScriptSystem dispatches `onCreate`/`onUpdate`/`onDestroy` per entity
- Per-script overridable lifecycle functions (onCreate, onUpdate, onDestroy, onCollision)
- Per-script `_G.sandbox` environment with blocked dofile/load/loadfile

### Bindings

| Table | Functions |
|-------|-----------|
| `caffeine.world` | create, destroy, hasComponent, getTransform, setTransform, getVelocity, setVelocity, getRigidBody2D, setRigidBody2D, getSprite, setSprite |
| `caffeine.input` | isKeyDown, getAxis, mousePosition, isMouseButtonDown |
| `caffeine.events` | on (subscribe), emit, off (unsubscribe) |
| `caffeine.debug` | log, warn, error |
| `caffeine.math` | vec2, add, sub, mul, scale, length, normalize, dot |

### Build

- Opt-in via `CAFFEINE_ENABLE_SCRIPTING=ON` (OFF by default)
- Fetches Lua 5.4.7 + sol2 v3.3.0 from source via FetchContent
- Python patch for sol2 optional<T&> GCC 16 compatibility
- Creates `lua.hpp` wrapper for C++-compatible lua header inclusion

### Bugfix

Fixed SIGSEGV in `ScriptSystem::onUpdate`: the original code processed scripts
inside `World::forEach`, which calls `setTransform` → `getOrAdd<Position2D>` →
`World::add<Position2D>`. This triggers archetype migration (entity moves to a
new archetype), which invalidates `forEach`'s stale `entityCount` — causing
out-of-bounds access and crash. Fix uses a two-phase approach: collect entity
data first, then process scripts outside iteration.

### Tests

19 standalone sequential tests covering init, lifecycle, input, math, events,
velocity, error handling, sandbox, multiple entities, engine isolation,
and repeated init/shutdown cycles. All pass.