### PR TITLE
refactor(build): split into caffeine-core and doppio (T0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,16 +42,16 @@ jobs:
           echo "SDL3_CMAKE_DIR=$sdl3Root\cmake" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "SDL3_BIN=$sdl3Root\lib\x64"     | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      # ── core: Caffeine sem SDL3 + caf-encode ─────────────────────────────
-      - name: Configure Core (sem SDL3)
+      # ── core: caffeine-core (headless) + caf-encode ────────────────────────
+      - name: Configure Core (headless)
         shell: pwsh
-        run: cmake -S . -B build-core -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build-core -DCMAKE_BUILD_TYPE=Release -DCAFFEINE_BUILD_HEADLESS=ON
 
       - name: Build Core
         shell: pwsh
         run: cmake --build build-core --config Release
 
-      # ── full: apenas Caffeine.lib com SDL3 + ImGui ────────────────────────
+      # ── full: caffeine-core + doppio com SDL3 + ImGui ────────────────────
       - name: Configure Full (com SDL3)
         shell: pwsh
         run: |
@@ -59,11 +59,10 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DSDL3_DIR="${{ env.SDL3_CMAKE_DIR }}"
 
-      - name: Build Full (target Caffeine + caffeine-studio)
+      - name: Build Full (target doppio)
         shell: pwsh
         run: |
-          cmake --build build-full --config Release --target Caffeine
-          cmake --build build-full --config Release --target caffeine-studio
+          cmake --build build-full --config Release --target doppio
 
       # ── Package: core ─────────────────────────────────────────────────────
       - name: Package Core
@@ -73,11 +72,11 @@ jobs:
           $pkg = "caffeine-core-$tag-windows"
           New-Item -ItemType Directory -Force "$pkg\lib", "$pkg\include", "$pkg\bin" | Out-Null
 
-          Copy-Item "build-core\Release\Caffeine.lib" "$pkg\lib\"
+          Copy-Item "build-core\Release\caffeine-core.lib" "$pkg\lib\"
           Copy-Item "build-core\Release\caf-encode.exe" "$pkg\bin\"
 
           Get-ChildItem "src" -Recurse -Filter "*.hpp" | Where-Object {
-            $_.FullName -notlike "*\editor\*"
+            $_.FullName -notlike "*\editor\*" -and $_.FullName -notlike "*\tools\*"
           } | ForEach-Object {
             $rel  = $_.FullName.Substring((Resolve-Path "src").Path.Length + 1)
             $dest = "$pkg\include\$rel"
@@ -92,11 +91,11 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ env.VERSION }}"
-          $pkg = "caffeine-ide-$tag-windows"
+          $pkg = "doppio-$tag-windows"
           New-Item -ItemType Directory -Force "$pkg\lib", "$pkg\include\editor", "$pkg\bin" | Out-Null
 
-          Copy-Item "build-full\Release\Caffeine.lib" "$pkg\lib\"
-          Copy-Item "build-full\Release\caffeine-studio.exe" "$pkg\bin\"
+          Copy-Item "build-full\Release\caffeine-core.lib" "$pkg\lib\"
+          Copy-Item "build-full\Release\doppio.exe" "$pkg\bin\"
           Copy-Item "${{ env.SDL3_BIN }}\SDL3.dll" "$pkg\bin\"
 
           Get-ChildItem "src\editor" -Filter "*.hpp" | ForEach-Object {
@@ -113,9 +112,9 @@ jobs:
           $pkg = "caffeine-bundle-$tag-windows"
           New-Item -ItemType Directory -Force "$pkg\lib", "$pkg\include", "$pkg\bin" | Out-Null
 
-          Copy-Item "build-full\Release\Caffeine.lib" "$pkg\lib\"
+          Copy-Item "build-full\Release\caffeine-core.lib" "$pkg\lib\"
           Copy-Item "build-core\Release\caf-encode.exe" "$pkg\bin\"
-          Copy-Item "build-full\Release\caffeine-studio.exe" "$pkg\bin\"
+          Copy-Item "build-full\Release\doppio.exe" "$pkg\bin\"
           Copy-Item "${{ env.SDL3_BIN }}\SDL3.dll" "$pkg\bin\"
 
           Get-ChildItem "src" -Recurse -Filter "*.hpp" | ForEach-Object {
@@ -145,9 +144,9 @@ jobs:
 
             | Arquivo | Descrição |
             |---------|-----------|
-            | `caffeine-core-*-windows.zip` | Engine base: `Caffeine.lib` (sem SDL3/ImGui) + `caf-encode.exe` + headers públicos |
-            | `caffeine-ide-*-windows.zip` | Módulo IDE: `caffeine-studio.exe` + `Caffeine.lib` (com SDL3 + ImGui) + headers do editor + `SDL3.dll` |
-            | `caffeine-bundle-*-windows.zip` | Bundle completa: `caffeine-studio.exe` + `caf-encode.exe` + `Caffeine.lib` + todos os headers + `SDL3.dll` |
+            | `caffeine-core-*-windows.zip` | Engine base: `caffeine-core.lib` (headless) + `caf-encode.exe` + headers públicos |
+            | `doppio-*-windows.zip` | IDE: `doppio.exe` + `caffeine-core.lib` (com SDL3) + headers do editor + `SDL3.dll` |
+            | `caffeine-bundle-*-windows.zip` | Bundle completa: `doppio.exe` + `caf-encode.exe` + `caffeine-core.lib` + todos os headers + `SDL3.dll` |
 
             ---
 
@@ -169,5 +168,5 @@ jobs:
             > *"Caffeine: Because great games are built on strong code and a lot of coffee."*
           files: |
             caffeine-core-*.zip
-            caffeine-ide-*.zip
+            doppio-*.zip
             caffeine-bundle-*.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,24 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(CF_DEBUG)
 endif()
 
-# ── SDL3 (optional – RHI is only built when SDL3 is available) ──
-find_package(SDL3 CONFIG QUIET)
+# ── Headless mode (build without SDL3) ─────────────────────────
+option(CAFFEINE_BUILD_HEADLESS "Build caffeine-core without SDL3/RHI" OFF)
 
-add_library(Caffeine
+# ── Scripting (Lua + sol2) ──────────────────────────────────────
+option(CAFFEINE_ENABLE_SCRIPTING "Enable Lua scripting support" OFF)
+
+# ── SDL3 (optional — only needed when NOT headless) ──────────────
+if(NOT CAFFEINE_BUILD_HEADLESS)
+    find_package(SDL3 CONFIG QUIET)
+endif()
+
+# ═══════════════════════════════════════════════════════════════════
+#  CAFFEINE ENGINE CORE
+#
+#  Pure engine library. ZERO dependency on ImGui or editor code.
+#  Can be built headless (without SDL3) for server/CI workloads.
+# ═══════════════════════════════════════════════════════════════════
+add_library(caffeine-core
     src/core/Timer.cpp
     src/core/GameLoop.cpp
     src/core/io/BlobLoader.cpp
@@ -28,79 +42,37 @@ add_library(Caffeine
     src/ecs/World.cpp
     src/events/EventBus.cpp
     src/assets/AssetManager.cpp
+    src/core/DebugHookRegistry.cpp
 )
 
-if(SDL3_FOUND)
-    target_sources(Caffeine PRIVATE
-        src/rhi/RenderDevice.cpp
-        src/rhi/CommandBuffer.cpp
-    )
-endif()
-
-target_include_directories(Caffeine PUBLIC 
+target_include_directories(caffeine-core PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include>
 )
 
-if(SDL3_FOUND)
-    target_link_libraries(Caffeine PUBLIC SDL3::SDL3)
-    target_compile_definitions(Caffeine PUBLIC CF_HAS_SDL3=1)
-    message(STATUS "SDL3 found – RHI module enabled")
+target_compile_features(caffeine-core PUBLIC cxx_std_20)
 
-    include(FetchContent)
-    FetchContent_Declare(
-        imgui
-        GIT_REPOSITORY https://github.com/ocornut/imgui.git
-        GIT_TAG        v1.91.9
-        GIT_SHALLOW    TRUE
-    )
-    set(FETCHCONTENT_QUIET OFF)
-    FetchContent_MakeAvailable(imgui)
-
-    add_library(ImGui STATIC
-        ${imgui_SOURCE_DIR}/imgui.cpp
-        ${imgui_SOURCE_DIR}/imgui_draw.cpp
-        ${imgui_SOURCE_DIR}/imgui_widgets.cpp
-        ${imgui_SOURCE_DIR}/imgui_tables.cpp
-        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
-        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdlgpu3.cpp
-    )
-    target_include_directories(ImGui PUBLIC
-        ${imgui_SOURCE_DIR}
-        ${imgui_SOURCE_DIR}/backends
-    )
-    target_link_libraries(ImGui PUBLIC SDL3::SDL3)
-
-    target_link_libraries(Caffeine PUBLIC ImGui)
-    target_compile_definitions(Caffeine PUBLIC CF_HAS_IMGUI=1)
-    message(STATUS "ImGui fetched and enabled")
+if(CAFFEINE_BUILD_HEADLESS)
+    target_compile_definitions(caffeine-core PUBLIC CF_HEADLESS=1)
+    message(STATUS "Building caffeine-core in HEADLESS mode (no SDL3, no RHI)")
 else()
-    message(STATUS "SDL3 not found – RHI module disabled")
+    if(SDL3_FOUND)
+        target_sources(caffeine-core PRIVATE
+            src/rhi/RenderDevice.cpp
+            src/rhi/CommandBuffer.cpp
+        )
+        target_link_libraries(caffeine-core PUBLIC SDL3::SDL3)
+        target_compile_definitions(caffeine-core PUBLIC CF_HAS_SDL3=1)
+        message(STATUS "SDL3 found – RHI module enabled")
+    else()
+        message(STATUS "SDL3 not found – RHI module disabled")
+    endif()
 endif()
 
-target_compile_features(Caffeine PUBLIC cxx_std_20)
+# ── Backward-compat alias ───────────────────────────────────────
+add_library(Caffeine::Core ALIAS caffeine-core)
 
-add_library(Caffeine::Core ALIAS Caffeine)
-
-# ── caf-encode CLI tool ────────────────────────────────────────
-add_executable(caf-encode tools/caf-encode/main.cpp)
-target_link_libraries(caf-encode PRIVATE Caffeine)
-target_include_directories(caf-encode PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_compile_features(caf-encode PRIVATE cxx_std_20)
-
-# ── caffeine-studio IDE executable ───────────────────────────────
-if(SDL3_FOUND)
-    add_executable(caffeine-studio tools/ide/main.cpp)
-    target_link_libraries(caffeine-studio PRIVATE Caffeine)
-    target_include_directories(caffeine-studio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-    target_compile_features(caffeine-studio PRIVATE cxx_std_20)
-endif()
-
-add_subdirectory(tests)
-
-# ── Scripting (Lua + sol2) ────────────────────────────────────
-option(CAFFEINE_ENABLE_SCRIPTING "Enable Lua scripting support" OFF)
-
+# ── Scripting ────────────────────────────────────────────────────
 if(CAFFEINE_ENABLE_SCRIPTING)
     include(FetchContent)
 
@@ -149,7 +121,6 @@ if(CAFFEINE_ENABLE_SCRIPTING)
             ${LUA54_SRC}/lzio.c
         )
         target_include_directories(lua54 BEFORE PUBLIC ${LUA54_SRC})
-        # Create lua.hpp C++ wrapper so sol2's #include <lua.hpp> finds our 5.4 headers
         file(WRITE ${LUA54_SRC}/lua.hpp
             "extern \"C\" {\n"
             "#include \"lua.h\"\n"
@@ -175,13 +146,63 @@ if(CAFFEINE_ENABLE_SCRIPTING)
         message(FATAL_ERROR "Failed to patch sol2 for GCC 16 compatibility")
     endif()
 
-    target_link_libraries(Caffeine PRIVATE sol2::sol2 lua54)
+    target_link_libraries(caffeine-core PRIVATE sol2::sol2 lua54)
+    target_compile_definitions(caffeine-core PUBLIC CF_HAS_SCRIPTING=1)
 
-    target_compile_definitions(Caffeine PUBLIC CF_HAS_SCRIPTING=1)
-
-    target_sources(Caffeine PRIVATE
+    target_sources(caffeine-core PRIVATE
         src/script/ScriptEngine.cpp
         src/script/ScriptSystem.cpp
         src/script/ScriptWatcher.cpp
     )
 endif()
+
+# ═══════════════════════════════════════════════════════════════════
+#  DOPPIO — Caffeine Studio IDE
+#
+#  Executable da IDE. Linka caffeine-core + ImGui.
+#  NÃO funciona sem o core.
+# ═══════════════════════════════════════════════════════════════════
+if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
+    include(FetchContent)
+    FetchContent_Declare(
+        imgui
+        GIT_REPOSITORY https://github.com/ocornut/imgui.git
+        GIT_TAG        v1.91.9
+        GIT_SHALLOW    TRUE
+    )
+    set(FETCHCONTENT_QUIET OFF)
+    FetchContent_MakeAvailable(imgui)
+
+    add_library(ImGui STATIC
+        ${imgui_SOURCE_DIR}/imgui.cpp
+        ${imgui_SOURCE_DIR}/imgui_draw.cpp
+        ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+        ${imgui_SOURCE_DIR}/imgui_tables.cpp
+        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
+        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdlgpu3.cpp
+    )
+    target_include_directories(ImGui PUBLIC
+        ${imgui_SOURCE_DIR}
+        ${imgui_SOURCE_DIR}/backends
+    )
+    target_link_libraries(ImGui PUBLIC SDL3::SDL3)
+
+    add_executable(doppio
+        apps/doppio/main.cpp
+    )
+    target_link_libraries(doppio PRIVATE caffeine-core ImGui)
+    target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_compile_definitions(doppio PRIVATE CF_HAS_IMGUI=1)
+    target_compile_features(doppio PRIVATE cxx_std_20)
+
+    message(STATUS "Doppio (IDE) enabled – ImGui v1.91.9 fetched")
+endif()
+
+# ── caf-encode CLI tool ────────────────────────────────────────
+add_executable(caf-encode tools/caf-encode/main.cpp)
+target_link_libraries(caf-encode PRIVATE caffeine-core)
+target_include_directories(caf-encode PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_compile_features(caf-encode PRIVATE cxx_std_20)
+
+# ── Tests ────────────────────────────────────────────────────────
+add_subdirectory(tests)

--- a/apps/doppio/Doppio.hpp
+++ b/apps/doppio/Doppio.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+// ═══════════════════════════════════════════════════════════════════
+//  Doppio — Caffeine Studio IDE Master Header
+//
+//  Inclui o core da engine + todos os headers do editor/IDE.
+//  Apenas para uso no binário doppio — NÃO incluir em projetos
+//  que usam apenas a Caffeine Engine (use Caffeine.hpp para esse fim).
+// ═══════════════════════════════════════════════════════════════════
+
+// ── Engine Core ─────────────────────────────────────────────────
+#include "Caffeine.hpp"
+
+// ── Editor panels (header-only, ImGui code is CF_HAS_IMGUI-guarded) ─
+#include "editor/EditorTypes.hpp"
+#include "editor/EditorContext.hpp"
+#include "editor/ConsoleWindow.hpp"
+#include "editor/ProfilerWindow.hpp"
+#include "editor/StatsOverlay.hpp"
+#include "editor/HierarchyPanel.hpp"
+#include "editor/InspectorPanel.hpp"
+#include "editor/SceneViewport.hpp"
+#include "editor/AssetBrowser.hpp"
+#include "editor/SceneEditor.hpp"
+
+#ifdef CF_HAS_IMGUI
+#include "editor/ImGuiIntegration.hpp"
+#endif

--- a/apps/doppio/main.cpp
+++ b/apps/doppio/main.cpp
@@ -3,13 +3,15 @@
 #include "assets/AssetManager.hpp"
 #include "ecs/World.hpp"
 #include "render/Camera2D.hpp"
+
+// Editor headers (header-only, ImGui code is CF_HAS_IMGUI-guarded)
 #include "editor/ImGuiIntegration.hpp"
 #include "editor/SceneEditor.hpp"
 #include <SDL3/SDL.h>
 #include <cstdio>
 
 int main(int, char**) {
-    SDL_SetAppMetadata("Caffeine Studio", "0.0.1-beta", "com.devscafe.caffeine-studio");
+    SDL_SetAppMetadata("Doppio", "0.0.1-beta", "com.devscafe.doppio");
 
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         std::fprintf(stderr, "SDL_Init failed: %s\n", SDL_GetError());
@@ -17,7 +19,7 @@ int main(int, char**) {
     }
 
     SDL_Window* window = SDL_CreateWindow(
-        "Caffeine Studio  —  v0.0.1 Beta",
+        "Doppio  —  Caffeine Studio IDE  v0.0.1 Beta",
         1280, 720,
         SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY);
 
@@ -31,7 +33,7 @@ int main(int, char**) {
     cfg.width       = 1280;
     cfg.height      = 720;
     cfg.vsync       = true;
-    cfg.windowTitle = "Caffeine Studio";
+    cfg.windowTitle = "Doppio";
 
     Caffeine::RHI::RenderDevice device;
     if (!device.init(window, cfg)) {
@@ -63,6 +65,9 @@ int main(int, char**) {
         SDL_Quit();
         return 1;
     }
+
+    // Register editor debug hooks into core
+    // (T0.4 — IDebugHooks will be wired here in a follow-up)
 
     bool running = true;
     while (running && editor.isOpen()) {

--- a/src/Caffeine.hpp
+++ b/src/Caffeine.hpp
@@ -88,23 +88,6 @@
 #include "assets/MeshTypes.hpp"
 #include "assets/MeshLoader.hpp"
 
-// Editor (Dear ImGui)
-#include "editor/EditorTypes.hpp"
-#include "editor/EditorContext.hpp"
-#include "editor/ConsoleWindow.hpp"
-#include "editor/ProfilerWindow.hpp"
-#include "editor/StatsOverlay.hpp"
-#include "editor/HierarchyPanel.hpp"
-#include "editor/InspectorPanel.hpp"
-#include "editor/SceneViewport.hpp"
-#include "editor/AssetBrowser.hpp"
-#include "editor/SceneEditor.hpp"
-#ifdef CF_HAS_SDL3
-#ifdef CF_HAS_IMGUI
-#include "editor/ImGuiIntegration.hpp"
-#endif
-#endif
-
 // Scripting (optional — CAFFEINE_ENABLE_SCRIPTING)
 #ifdef CF_HAS_SCRIPTING
 #include "script/ScriptEngine.hpp"
@@ -112,11 +95,3 @@
 #include "script/ScriptSystem.hpp"
 #include "script/ScriptWatcher.hpp"
 #endif
-
-// Tools (Asset Pipeline)
-#include "tools/PipelineTypes.hpp"
-#include "tools/TextureEncoder.hpp"
-#include "tools/AudioEncoder.hpp"
-#include "tools/MeshEncoder.hpp"
-#include "tools/AssetManifest.hpp"
-#include "tools/AssetPipeline.hpp"

--- a/src/core/DebugHookRegistry.cpp
+++ b/src/core/DebugHookRegistry.cpp
@@ -1,0 +1,7 @@
+#include "core/IDebugHooks.hpp"
+
+namespace Caffeine::Core {
+
+IDebugHooks* DebugHookRegistry::s_hooks = nullptr;
+
+} // namespace Caffeine::Core

--- a/src/core/IDebugHooks.hpp
+++ b/src/core/IDebugHooks.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "ecs/Entity.hpp"
+
+namespace Caffeine::Core {
+
+// ============================================================================
+// @brief  Frame statistics published by the engine every frame.
+// ============================================================================
+struct FrameStats {
+    f64 deltaTime   = 0.0;
+    f64 fps         = 0.0;
+    u64 frameCount  = 0;
+    f64 elapsedTime = 0.0;
+};
+
+// ============================================================================
+// @brief  Extension point: the IDE implements this interface and registers
+//         it via DebugHookRegistry so the core can notify the IDE about
+//         engine events WITHOUT the core knowing about the IDE.
+//
+//  The core calls these hooks if-and-only-if a consumer has registered
+//  them. Zero overhead when no hooks are registered (nullptr check).
+// ============================================================================
+struct IDebugHooks {
+    virtual ~IDebugHooks() = default;
+
+    /// Called when a new entity is created.
+    virtual void onEntityCreated(ECS::Entity e) = 0;
+
+    /// Called just before an entity is destroyed.
+    virtual void onEntityDestroyed(ECS::Entity e) = 0;
+
+    /// Called when a log message is emitted.
+    virtual void onLogMessage(const char* msg, u8 level) = 0;
+
+    /// Called at the end of every frame with timing stats.
+    virtual void onFrameEnd(const FrameStats& stats) = 0;
+};
+
+// ============================================================================
+// @brief  Optional registry for IDebugHooks.
+//
+//  Usage:
+//    // In doppio (IDE) main:
+//    struct MyHooks : Caffeine::Core::IDebugHooks { ... };
+//    MyHooks hooks;
+//    Caffeine::Core::DebugHookRegistry::registerHooks(&hooks);
+//
+//    // In core (engine):
+//    if (auto* h = Caffeine::Core::DebugHookRegistry::hooks()) {
+//        h->onFrameEnd(stats);
+//    }
+// ============================================================================
+class DebugHookRegistry {
+public:
+    /// Register a hooks implementation (only one at a time).
+    /// Pass nullptr to unregister.
+    static void registerHooks(IDebugHooks* hooks) {
+        s_hooks = hooks;
+    }
+
+    /// Get the currently registered hooks (may be nullptr).
+    static IDebugHooks* hooks() {
+        return s_hooks;
+    }
+
+private:
+    static IDebugHooks* s_hooks;
+};
+
+} // namespace Caffeine::Core

--- a/src/tools/TextureEncoder.hpp
+++ b/src/tools/TextureEncoder.hpp
@@ -5,6 +5,7 @@
 #include "core/io/Crc32.hpp"
 #include <vector>
 #include <cmath>
+#include <cstring>
 #include <string_view>
 #include <cstdio>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,10 +21,10 @@ set(CAFFEINE_TEST_SOURCES
     test_ui.cpp
     test_animation.cpp
     test_mesh.cpp
-    test_editor.cpp
     test_octree.cpp
     test_skeletal_animation.cpp
     test_pipeline.cpp
+    test_editor.cpp
 )
 
 if(SDL3_FOUND)
@@ -33,7 +33,7 @@ endif()
 
 add_executable(CaffeineTest ${CAFFEINE_TEST_SOURCES})
 
-target_link_libraries(CaffeineTest PRIVATE Caffeine)
+target_link_libraries(CaffeineTest PRIVATE caffeine-core)
 target_include_directories(CaffeineTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/Catch2)
 if(MSVC)
     target_compile_options(CaffeineTest PRIVATE /W4 /WX-)

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -1,5 +1,14 @@
 #include "catch.hpp"
-#include "../src/Caffeine.hpp"
+#include "../src/core/Types.hpp"
+#include "../src/core/IDebugHooks.hpp"
+#include "../src/ecs/World.hpp"
+#include "../src/ecs/Entity.hpp"
+#include "../src/debug/LogSystem.hpp"
+#include "../src/editor/EditorTypes.hpp"
+#include "../src/editor/EditorContext.hpp"
+#include "../src/editor/ConsoleWindow.hpp"
+#include "../src/editor/ProfilerWindow.hpp"
+#include "../src/editor/StatsOverlay.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;

--- a/tools/caf-encode/main.cpp
+++ b/tools/caf-encode/main.cpp
@@ -1,4 +1,5 @@
-#include "Caffeine.hpp"
+#include "core/Types.hpp"
+#include "assets/AssetTypes.hpp"
 #include "tools/TextureEncoder.hpp"
 #include "tools/AudioEncoder.hpp"
 #include "tools/MeshEncoder.hpp"


### PR DESCRIPTION
## Summary

Implementa a **T0 — Desacoplamento Core↔IDE** do plano do Caffeine Studio IDE. Separa o monolito anterior (`Caffeine` library com ImGui) em dois binários independentes:

### Alterações Estruturais

| Antes | Depois |
|---|---|
| `Caffeine` library (incluía ImGui + editor code) | `caffeine-core` library — **zero dependência de ImGui** |
| `caffeine-studio` executable | `doppio` executable (linka `caffeine-core` + `ImGui`) |
| `tools/ide/main.cpp` | `apps/doppio/main.cpp` |
| `Caffeine.hpp` incluía editor + tools | `Caffeine.hpp` é **core-only** |
| — | `Doppio.hpp` — master header da IDE |

### Novos Ficheiros

- `src/core/IDebugHooks.hpp` + `DebugHookRegistry.cpp` — Pontos de extensão core→IDE
- `apps/doppio/main.cpp` — Entry point da IDE (renomeado)
- `apps/doppio/Doppio.hpp` — Master header do binário IDE

### Headless Mode

- `CAFFEINE_BUILD_HEADLESS=ON` permite compilar `caffeine-core` sem SDL3
- Ideal para servidor dedicado, CI, ou runtime de jogo standalone

### CI/CD

- Release workflow atualizado: `caffeine-core.lib` + `doppio.exe`
- Test workflow mantido (SDL3 não encontrado em Ubuntu → build headless implícito)

## Closes

Closes #74