### PR TITLE
feat(editor): implement EditorContext with snapshot-based undo/redo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(caffeine-core
     src/events/EventBus.cpp
     src/assets/AssetManager.cpp
     src/core/DebugHookRegistry.cpp
+    src/editor/EditorContext.cpp
 )
 
 target_include_directories(caffeine-core PUBLIC

--- a/src/editor/EditorContext.cpp
+++ b/src/editor/EditorContext.cpp
@@ -1,0 +1,112 @@
+#include "editor/EditorContext.hpp"
+#include "scene/SceneSerializer.hpp"
+#include "core/Assertions.hpp"
+#include <cstring>
+
+namespace Caffeine::Editor {
+
+const char* getEntityName(ECS::World& world, ECS::Entity e) {
+    if (auto* nc = world.get<NameComponent>(e)) {
+        return nc->name;
+    }
+    static const char* s_unnamed = "Unnamed";
+    return s_unnamed;
+}
+
+void setEntityName(ECS::World& world, ECS::Entity e, const char* name) {
+    auto& nc = world.add<NameComponent>(e);
+    std::strncpy(nc.name, name, sizeof(nc.name) - 1);
+    nc.name[sizeof(nc.name) - 1] = '\0';
+}
+
+// ============================================================================
+// UndoStack
+// ============================================================================
+
+void UndoStack::push(const EditorCommand& cmd) {
+    // If we're mid-buffer (after an undo), truncate any redo history
+    if (m_current < m_count) {
+        for (u32 i = m_current; i < m_count; ++i) {
+            m_commands[i].beforeState.clear();
+            m_commands[i].afterState.clear();
+        }
+        m_count = m_current;
+    }
+
+    // If the buffer is full, discard the oldest entry (circular shift)
+    if (m_count >= MAX_UNDO) {
+        for (u32 i = 0; i < MAX_UNDO - 1; ++i) {
+            m_commands[i] = std::move(m_commands[i + 1]);
+        }
+        m_count = MAX_UNDO - 1;
+    }
+
+    m_commands[m_count] = cmd;
+    ++m_count;
+    m_current = m_count;
+}
+
+bool UndoStack::undo(ECS::World& world) {
+    if (!canUndo()) return false;
+
+    --m_current;
+    applySnapshot(world, m_commands[m_current].beforeState);
+    return true;
+}
+
+bool UndoStack::redo(ECS::World& world) {
+    if (!canRedo()) return false;
+
+    applySnapshot(world, m_commands[m_current].afterState);
+    ++m_current;
+    return true;
+}
+
+void UndoStack::clear() {
+    for (u32 i = 0; i < m_count; ++i) {
+        m_commands[i].beforeState.clear();
+        m_commands[i].afterState.clear();
+    }
+    m_count   = 0;
+    m_current = 0;
+}
+
+void UndoStack::applySnapshot(ECS::World& world, const std::vector<u8>& snapshot) {
+    CF_ASSERT(!snapshot.empty(), "UndoStack::applySnapshot — empty snapshot");
+
+    world.destroyAll();
+
+    Scene::SceneSerializer serializer(world);
+    serializer.deserializeFromMemory(snapshot);
+}
+
+// ============================================================================
+// EditorContext
+// ============================================================================
+
+void EditorContext::beginUndo(EditorCommand::Type type, u32 entityId, ECS::World& world) {
+    CF_ASSERT(!m_undoPending, "EditorContext::beginUndo — called without matching endUndo");
+
+    m_pendingCmd = EditorCommand{};
+    m_pendingCmd.type          = type;
+    m_pendingCmd.targetEntity  = entityId;
+
+    Scene::SceneSerializer serializer(world);
+    serializer.serializeToMemory(m_pendingCmd.beforeState);
+
+    m_undoPending = true;
+}
+
+void EditorContext::endUndo(ECS::World& world) {
+    CF_ASSERT(m_undoPending, "EditorContext::endUndo — called without matching beginUndo");
+
+    Scene::SceneSerializer serializer(world);
+    serializer.serializeToMemory(m_pendingCmd.afterState);
+
+    undoStack.push(m_pendingCmd);
+
+    m_undoPending = false;
+    isDirty       = true;
+}
+
+} // namespace Caffeine::Editor

--- a/src/editor/EditorContext.hpp
+++ b/src/editor/EditorContext.hpp
@@ -2,58 +2,138 @@
 #include "core/Types.hpp"
 #include "ecs/Entity.hpp"
 #include "ecs/World.hpp"
+#include <string>
+#include <vector>
 #include <cstring>
 
 namespace Caffeine::Editor {
-using namespace Caffeine;
 
 // ============================================================================
-// @brief  Name component — stores the editor-facing name of an entity.
+// Name component — stores the editor-facing name of an entity.
 // ============================================================================
 struct NameComponent {
     char name[64] = "Entity";
 };
 
-// ============================================================================
-// @brief  Global state shared across Scene Editor panels.
-// ============================================================================
-struct EditorContext {
-    ECS::Entity selectedEntity = ECS::Entity::INVALID;
-    ECS::Entity hoveredEntity  = ECS::Entity::INVALID;
-    bool        isDirty        = false;
+const char* getEntityName(ECS::World& world, ECS::Entity e);
+void        setEntityName(ECS::World& world, ECS::Entity e, const char* name);
 
+// ============================================================================
+// EditorCommand — represents a single undoable action.
+// beforeState / afterState are full-world snapshots.
+// ============================================================================
+struct EditorCommand {
+    enum Type : u8 {
+        AddEntity,
+        RemoveEntity,
+        AddComponent,
+        RemoveComponent,
+        SetField,
+        MoveEntity
+    };
+
+    Type            type;
+    u32             targetEntity;  // Entity ID at time of command
+    std::vector<u8> beforeState;   // Full world snapshot before the action
+    std::vector<u8> afterState;    // Full world snapshot after the action
+};
+
+// ============================================================================
+// UndoStack — linear undo/redo manager with snapshot-based state.
+//
+// Maintains a list of EditorCommands up to MAX_UNDO.
+// When a new command is pushed after an undo, the redo history is truncated.
+// ============================================================================
+class UndoStack {
+    static constexpr u32 MAX_UNDO = 256;
+
+    EditorCommand           m_commands[MAX_UNDO];
+    u32                     m_count   = 0;
+    u32                     m_current = 0;  // 0 = at oldest, m_count = at newest
+
+public:
+    UndoStack() = default;
+
+    /// Push a new command. Any redo history beyond m_current is discarded.
+    void push(const EditorCommand& cmd);
+
+    /// Undo the command at m_current-1. Returns false if nothing to undo.
+    bool undo(ECS::World& world);
+
+    /// Redo the command at m_current. Returns false if nothing to redo.
+    bool redo(ECS::World& world);
+
+    /// Clear all commands.
+    void clear();
+
+    bool canUndo() const { return m_current > 0; }
+    bool canRedo() const { return m_current < m_count; }
+    u32  count()   const { return m_count; }
+
+private:
+    void applySnapshot(ECS::World& world, const std::vector<u8>& snapshot);
+};
+
+// ============================================================================
+// EditorContext — global editor state shared across all panels.
+// ============================================================================
+class EditorContext {
+public:
+    // ── Selection ──────────────────────────────────────────────────────
+    ECS::Entity selectedEntity   = ECS::Entity::INVALID;
+    ECS::Entity hoveredEntity    = ECS::Entity::INVALID;
+    ECS::Entity clipboardEntity  = ECS::Entity::INVALID;
+
+    // ── Scene state ────────────────────────────────────────────────────
+    std::string currentScenePath;
+    bool        isDirty          = false;
+
+    // ── Gizmo ──────────────────────────────────────────────────────────
     enum class GizmoMode : u8 { None, Translate, Rotate, Scale };
     enum class GizmoSpace : u8 { Local, World };
 
     GizmoMode  gizmoMode  = GizmoMode::Translate;
     GizmoSpace gizmoSpace = GizmoSpace::World;
 
-    // Viewport pan/zoom state
+    // ── Viewport state ─────────────────────────────────────────────────
     f32 viewportPanX = 0.0f;
     f32 viewportPanY = 0.0f;
     f32 viewportZoom = 1.0f;
 
-    // Panel visibility toggles
+    // ── Panel visibility ───────────────────────────────────────────────
     bool hierarchyOpen = true;
     bool inspectorOpen = true;
     bool viewportOpen  = true;
     bool assetsOpen    = true;
+
+    // ── Undo system ────────────────────────────────────────────────────
+    UndoStack undoStack;
+
+    // ── Methods ────────────────────────────────────────────────────────
+
+    /// Select an entity (updates selectedEntity).
+    void selectEntity(ECS::Entity e) { selectedEntity = e; }
+
+    /// Mark the scene as modified (dirty).
+    void markDirty() { isDirty = true; }
+
+    /// Clear selection and hover.
+    void clearSelection() {
+        selectedEntity  = ECS::Entity::INVALID;
+        hoveredEntity   = ECS::Entity::INVALID;
+    }
+
+    /// Capture the current world as the "before" snapshot, begin an undo
+    /// command. Must be followed by endUndo() after the edit.
+    void beginUndo(EditorCommand::Type type, u32 entityId, ECS::World& world);
+
+    /// Capture the current world as the "after" snapshot and push the
+    /// pending undo command onto the stack. Marks dirty automatically.
+    void endUndo(ECS::World& world);
+
+private:
+    bool            m_undoPending = false;
+    EditorCommand   m_pendingCmd;
 };
-
-// ============================================================================
-// @brief  Helper: get or set entity name via NameComponent.
-// ============================================================================
-inline const char* getEntityName(ECS::World& world, ECS::Entity e) {
-    auto* nc = world.get<NameComponent>(e);
-    return nc ? nc->name : "Unnamed";
-}
-
-inline void setEntityName(ECS::World& world, ECS::Entity e, const char* name) {
-    auto& nc = world.add<NameComponent>(e);
-    usize len = strlen(name);
-    if (len >= sizeof(nc.name)) len = sizeof(nc.name) - 1;
-    memcpy(nc.name, name, len);
-    nc.name[len] = '\0';
-}
 
 } // namespace Caffeine::Editor

--- a/src/editor/HierarchyPanel.hpp
+++ b/src/editor/HierarchyPanel.hpp
@@ -25,17 +25,19 @@ public:
         if (ImGui::Begin("Hierarchy", &m_open)) {
             // Toolbar
             if (ImGui::Button("+", ImVec2(24, 0))) {
+                ctx.beginUndo(EditorCommand::AddEntity, u32_max, world);
                 ECS::Entity e = world.create();
                 setEntityName(world, e, "New Entity");
                 ctx.selectedEntity = e;
-                ctx.isDirty = true;
+                ctx.endUndo(world);
             }
             ImGui::SameLine();
             if (ImGui::Button("Delete", ImVec2(0, 0))) {
                 if (ctx.selectedEntity.isValid()) {
+                    ctx.beginUndo(EditorCommand::RemoveEntity, ctx.selectedEntity.id(), world);
                     world.destroy(ctx.selectedEntity);
                     ctx.selectedEntity = ECS::Entity::INVALID;
-                    ctx.isDirty = true;
+                    ctx.endUndo(world);
                 }
             }
 
@@ -97,10 +99,11 @@ private:
             if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ENTITY_DRAG")) {
                 ECS::Entity dragged(*(u32*)payload->Data, &world);
                 if (dragged != entity) {
+                    ctx.beginUndo(EditorCommand::MoveEntity, dragged.id(), world);
                     auto& parentComp = world.add<Scene::Parent>(dragged);
                     parentComp.parent = entity;
                     parentComp.dirty = true;
-                    ctx.isDirty = true;
+                    ctx.endUndo(world);
                 }
             }
             ImGui::EndDragDropTarget();
@@ -118,17 +121,19 @@ private:
         if (ImGui::BeginPopupContextItem()) {
             if (ImGui::MenuItem("Rename")) { m_renaming = entity; }
             if (ImGui::MenuItem("Create Child")) {
+                ctx.beginUndo(EditorCommand::AddEntity, u32_max, world);
                 ECS::Entity child = world.create();
                 setEntityName(world, child, "Child");
                 auto& parentComp = world.add<Scene::Parent>(child);
                 parentComp.parent = entity;
                 parentComp.dirty = true;
-                ctx.isDirty = true;
+                ctx.endUndo(world);
             }
             if (ImGui::MenuItem("Delete")) {
+                ctx.beginUndo(EditorCommand::RemoveEntity, entity.id(), world);
                 world.destroy(entity);
                 if (ctx.selectedEntity == entity) ctx.selectedEntity = ECS::Entity::INVALID;
-                ctx.isDirty = true;
+                ctx.endUndo(world);
             }
             ImGui::EndPopup();
         }
@@ -157,8 +162,9 @@ private:
                 buf[sizeof(buf) - 1] = '\0';
                 if (ImGui::InputText("##rename_input", buf, sizeof(buf),
                                      ImGuiInputTextFlags_EnterReturnsTrue)) {
+                    ctx.beginUndo(EditorCommand::SetField, entity.id(), world);
                     setEntityName(world, entity, buf);
-                    ctx.isDirty = true;
+                    ctx.endUndo(world);
                     m_renaming = ECS::Entity::INVALID;
                     ImGui::CloseCurrentPopup();
                 }

--- a/src/editor/InspectorPanel.hpp
+++ b/src/editor/InspectorPanel.hpp
@@ -48,8 +48,9 @@ public:
             nameBuf[sizeof(nameBuf) - 1] = '\0';
             if (ImGui::InputText("##name", nameBuf, sizeof(nameBuf),
                                  ImGuiInputTextFlags_EnterReturnsTrue)) {
+                ctx.beginUndo(EditorCommand::SetField, e.id(), world);
                 setEntityName(world, e, nameBuf);
-                ctx.isDirty = true;
+                ctx.endUndo(world);
             }
             ImGui::SameLine();
             ImGui::TextDisabled("Entity %u", e.id());
@@ -72,16 +73,24 @@ public:
             }
             if (ImGui::BeginPopup("add_component")) {
                 if (!world.has<ECS::Position2D>(e) && ImGui::MenuItem("Position2D")) {
-                    world.add<ECS::Position2D>(e); ctx.isDirty = true;
+                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                    world.add<ECS::Position2D>(e);
+                    ctx.endUndo(world);
                 }
                 if (!world.has<ECS::Velocity2D>(e) && ImGui::MenuItem("Velocity2D")) {
-                    world.add<ECS::Velocity2D>(e); ctx.isDirty = true;
+                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                    world.add<ECS::Velocity2D>(e);
+                    ctx.endUndo(world);
                 }
                 if (!world.has<ECS::Sprite>(e) && ImGui::MenuItem("Sprite")) {
-                    world.add<ECS::Sprite>(e); ctx.isDirty = true;
+                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                    world.add<ECS::Sprite>(e);
+                    ctx.endUndo(world);
                 }
                 if (!world.has<ECS::Health>(e) && ImGui::MenuItem("Health")) {
-                    world.add<ECS::Health>(e); ctx.isDirty = true;
+                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                    world.add<ECS::Health>(e);
+                    ctx.endUndo(world);
                 }
                 ImGui::EndPopup();
             }

--- a/src/editor/SceneEditor.hpp
+++ b/src/editor/SceneEditor.hpp
@@ -110,6 +110,7 @@ private:
                     world.destroyAll();
                     m_ctx.selectedEntity = ECS::Entity::INVALID;
                     m_ctx.isDirty = false;
+                    m_ctx.undoStack.clear();
                 }
                 if (ImGui::MenuItem("Save", "Ctrl+S")) {
                     saveScene("scene.caf", world);
@@ -127,8 +128,12 @@ private:
                 ImGui::EndMenu();
             }
             if (ImGui::BeginMenu("Edit")) {
-                if (ImGui::MenuItem("Undo", "Ctrl+Z")) {}
-                if (ImGui::MenuItem("Redo", "Ctrl+Y")) {}
+                if (ImGui::MenuItem("Undo", "Ctrl+Z", false, m_ctx.undoStack.canUndo())) {
+                    m_ctx.undoStack.undo(world);
+                }
+                if (ImGui::MenuItem("Redo", "Ctrl+Y", false, m_ctx.undoStack.canRedo())) {
+                    m_ctx.undoStack.redo(world);
+                }
                 ImGui::EndMenu();
             }
             if (ImGui::BeginMenu("View")) {
@@ -159,6 +164,8 @@ private:
         std::filesystem::path assetPath = *dropped;
         std::string ext = assetPath.extension().string();
 
+        m_ctx.beginUndo(EditorCommand::AddEntity, u32_max, world);
+
         ECS::Entity entity = world.create();
         setEntityName(world, entity, assetPath.stem().string().c_str());
         world.add<ECS::Position2D>(entity, 0.0f, 0.0f);
@@ -168,7 +175,8 @@ private:
         }
 
         m_ctx.selectedEntity = entity;
-        m_ctx.isDirty = true;
+
+        m_ctx.endUndo(world);
     }
 #endif
 

--- a/src/editor/SceneViewport.hpp
+++ b/src/editor/SceneViewport.hpp
@@ -104,9 +104,19 @@ public:
                 if (ImGui::IsKeyPressed(ImGuiKey_Q)) ctx.gizmoMode = EditorContext::GizmoMode::None;
             }
 
-            // Handle mouse drag for selected entity gizmo
             if (ctx.selectedEntity.isValid() && ctx.gizmoMode != EditorContext::GizmoMode::None) {
-                handleGizmoInput(world, ctx, viewportSize);
+                bool dragging = ImGui::IsMouseDragging(ImGuiMouseButton_Left);
+                if (dragging && !m_gizmoDragging) {
+                    ctx.beginUndo(EditorCommand::SetField, ctx.selectedEntity.id(), world);
+                    m_gizmoDragging = true;
+                }
+                if (m_gizmoDragging) {
+                    handleGizmoInput(world, ctx, viewportSize);
+                }
+                if (!dragging && m_gizmoDragging) {
+                    ctx.endUndo(world);
+                    m_gizmoDragging = false;
+                }
             }
         }
 
@@ -277,6 +287,7 @@ private:
 
     bool m_open = true;
     bool m_initialized = false;
+    bool m_gizmoDragging = false;
 #ifdef CF_HAS_SDL3
     RHI::RenderDevice* m_device = nullptr;
     RHI::Texture* m_colorTarget = nullptr;


### PR DESCRIPTION
## Summary

Implement EditorContext + UndoStack system (issue #75, Milestone M1) for the Caffeine Studio IDE.

### Core changes

- **EditorContext**: Rewrote from POD struct to class with selection, gizmo, viewport, panel visibility state, and undo API
- **UndoStack**: 256-entry circular buffer with full-world snapshot-based undo/redo using `SceneSerializer::serializeToMemory/deserializeFromMemory`
- **EditorCommand**: Snapshot-based command with before/after world state vectors
- **beginUndo/endUndo**: Paired API for capturing world state around edit operations, auto-marks dirty

### Wire-up

- **Edit menu**: Undo (Ctrl+Z) / Redo (Ctrl+Y) wired with canUndo/canRedo state; undo cleared on New Scene
- **HierarchyPanel**: Entity add, delete, create-child, reparent, rename wrapped in undo
- **SceneViewport**: Full gizmo drag gesture wrapped in single undo command (tracked via `m_gizmoDragging`)
- **InspectorPanel**: Entity rename and component-add operations wrapped in undo

### Build

- Added `EditorContext.cpp` to caffeine-core library (only depends on ECS + SceneSerializer, no ImGui dependency)