### PR TITLE
feat(editor): implement dedicated HierarchyPanel with search, context menu, delete key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
 
     add_executable(doppio
         apps/doppio/main.cpp
+        src/editor/HierarchyPanel.cpp
     )
     target_link_libraries(doppio PRIVATE caffeine-core ImGui)
     target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/editor/HierarchyPanel.cpp
+++ b/src/editor/HierarchyPanel.cpp
@@ -1,0 +1,259 @@
+#include "editor/HierarchyPanel.hpp"
+#include <cctype>
+
+#ifdef CF_HAS_IMGUI
+
+namespace Caffeine::Editor {
+
+// ── Public render methods ────────────────────────────────────────
+
+void HierarchyPanel::render(ECS::World& world, EditorContext& ctx) {
+    m_world   = &world;
+    m_context = &ctx;
+    onImGuiRender();
+}
+
+void HierarchyPanel::onImGuiRender() {
+    if (!m_open) return;
+    if (!m_context || !m_world) return;
+
+    ImGui::Begin("Hierarchy", &m_open);
+
+    renderSearchBar();
+    renderToolbar();
+
+    ImGui::Separator();
+
+    if (ImGui::BeginChild("entity_list")) {
+        handleDeleteKey();
+
+        m_entityCount = 0;
+
+        ECS::ComponentQuery allQ;
+        bool hasFilter = (m_searchFilter[0] != '\0');
+
+        m_world->forEach<NameComponent>(allQ, [&](ECS::Entity e, NameComponent& nc) {
+            if (m_entityCount >= MAX_VISIBLE) return;
+
+            bool isRoot = true;
+            if (auto* parent = m_world->get<Scene::Parent>(e)) {
+                if (parent->parent.isValid()) isRoot = false;
+            }
+
+            if (!hasFilter) {
+                if (isRoot) {
+                    m_entities[m_entityCount++] = e;
+                }
+            } else {
+                const char* name = getEntityName(*m_world, e);
+                bool match = false;
+                for (const char* n = name; *n; ++n) {
+                    const char* fn = m_searchFilter;
+                    const char* nn = n;
+                    while (*nn && *fn && std::tolower(static_cast<unsigned char>(*nn)) == std::tolower(static_cast<unsigned char>(*fn))) {
+                        ++nn; ++fn;
+                    }
+                    if (!*fn) { match = true; break; }
+                }
+
+                if (match) {
+                    m_entities[m_entityCount++] = e;
+                }
+            }
+        });
+
+        for (u32 i = 0; i < m_entityCount; ++i) {
+            renderEntityNode(m_entities[i]);
+        }
+
+        renderEmptyContextMenu();
+    }
+    ImGui::EndChild();
+
+    ImGui::End();
+}
+
+// ── Search bar ───────────────────────────────────────────────────
+
+void HierarchyPanel::renderSearchBar() {
+    ImGui::PushItemWidth(-1);
+    ImGui::InputTextWithHint("##hierarchy_search", "Search entities...",
+                             m_searchFilter, sizeof(m_searchFilter));
+    ImGui::PopItemWidth();
+}
+
+// ── Toolbar ──────────────────────────────────────────────────────
+
+void HierarchyPanel::renderToolbar() {
+    if (ImGui::Button("+", ImVec2(24, 0))) {
+        m_context->beginUndo(EditorCommand::AddEntity, u32_max, *m_world);
+        ECS::Entity e = m_world->create();
+        setEntityName(*m_world, e, "New Entity");
+        m_context->selectedEntity = e;
+        m_context->endUndo(*m_world);
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Delete", ImVec2(0, 0))) {
+        if (m_context->selectedEntity.isValid()) {
+            m_context->beginUndo(EditorCommand::RemoveEntity,
+                                m_context->selectedEntity.id(), *m_world);
+            m_world->destroy(m_context->selectedEntity);
+            m_context->selectedEntity = ECS::Entity::INVALID;
+            m_context->endUndo(*m_world);
+        }
+    }
+}
+
+// ── Delete key ───────────────────────────────────────────────────
+
+void HierarchyPanel::handleDeleteKey() {
+    if (ImGui::IsWindowFocused() && ImGui::IsKeyPressed(ImGuiKey_Delete)) {
+        if (m_context->selectedEntity.isValid()) {
+            m_context->beginUndo(EditorCommand::RemoveEntity,
+                                m_context->selectedEntity.id(), *m_world);
+            m_world->destroy(m_context->selectedEntity);
+            m_context->selectedEntity = ECS::Entity::INVALID;
+            m_context->endUndo(*m_world);
+        }
+    }
+}
+
+// ── Entity tree node ─────────────────────────────────────────────
+
+void HierarchyPanel::renderEntityNode(ECS::Entity entity) {
+    if (!entity.isValid()) return;
+
+    const char* name = getEntityName(*m_world, entity);
+
+    ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow
+                             | ImGuiTreeNodeFlags_SpanAvailWidth;
+    if (m_context->selectedEntity == entity) {
+        flags |= ImGuiTreeNodeFlags_Selected;
+    }
+
+    bool childExists = hasChildren(entity);
+    if (!childExists) {
+        flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+    }
+
+    bool open = ImGui::TreeNodeEx((void*)(uintptr_t)entity.id(), flags, "%s", name);
+
+    if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen()) {
+        m_context->selectedEntity = entity;
+    }
+
+    if (ImGui::BeginDragDropTarget()) {
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ENTITY_DRAG")) {
+            ECS::Entity dragged(*(u32*)payload->Data, m_world);
+            if (dragged != entity) {
+                m_context->beginUndo(EditorCommand::MoveEntity, dragged.id(), *m_world);
+                auto& parentComp = m_world->add<Scene::Parent>(dragged);
+                parentComp.parent = entity;
+                parentComp.dirty = true;
+                m_context->endUndo(*m_world);
+            }
+        }
+        ImGui::EndDragDropTarget();
+    }
+
+    if (ImGui::BeginDragDropSource()) {
+        u32 eid = entity.id();
+        ImGui::SetDragDropPayload("ENTITY_DRAG", &eid, sizeof(u32));
+        ImGui::Text("%s", name);
+        ImGui::EndDragDropSource();
+    }
+
+    if (ImGui::BeginPopupContextItem()) {
+        if (ImGui::MenuItem("Rename")) { m_renaming = entity; }
+        if (ImGui::MenuItem("Create Child")) {
+            m_context->beginUndo(EditorCommand::AddEntity, u32_max, *m_world);
+            ECS::Entity child = m_world->create();
+            setEntityName(*m_world, child, "Child");
+            auto& parentComp = m_world->add<Scene::Parent>(child);
+            parentComp.parent = entity;
+            parentComp.dirty = true;
+            m_context->endUndo(*m_world);
+        }
+        if (ImGui::MenuItem("Delete")) {
+            m_context->beginUndo(EditorCommand::RemoveEntity, entity.id(), *m_world);
+            m_world->destroy(entity);
+            if (m_context->selectedEntity == entity) {
+                m_context->selectedEntity = ECS::Entity::INVALID;
+            }
+            m_context->endUndo(*m_world);
+        }
+        ImGui::EndPopup();
+    }
+
+    if (childExists && open) {
+        renderChildren(entity);
+        ImGui::TreePop();
+    }
+
+    if (m_renaming == entity) {
+        ImGui::OpenPopup("##rename");
+        if (ImGui::BeginPopup("##rename")) {
+            ImGui::Text("Rename: %s", name);
+            char buf[64];
+            const char* curName = getEntityName(*m_world, entity);
+            std::strncpy(buf, curName, sizeof(buf));
+            buf[sizeof(buf) - 1] = '\0';
+            if (ImGui::InputText("##rename_input", buf, sizeof(buf),
+                                 ImGuiInputTextFlags_EnterReturnsTrue)) {
+                m_context->beginUndo(EditorCommand::SetField, entity.id(), *m_world);
+                setEntityName(*m_world, entity, buf);
+                m_context->endUndo(*m_world);
+                m_renaming = ECS::Entity::INVALID;
+                ImGui::CloseCurrentPopup();
+            }
+            if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+                m_renaming = ECS::Entity::INVALID;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        } else {
+            m_renaming = ECS::Entity::INVALID;
+        }
+    }
+}
+
+// ── Empty space context menu ─────────────────────────────────────
+
+void HierarchyPanel::renderEmptyContextMenu() {
+    if (ImGui::BeginPopupContextWindow("hierarchy_empty_ctx")) {
+        if (ImGui::MenuItem("Create Empty Entity")) {
+            m_context->beginUndo(EditorCommand::AddEntity, u32_max, *m_world);
+            ECS::Entity e = m_world->create();
+            setEntityName(*m_world, e, "New Entity");
+            m_context->selectedEntity = e;
+            m_context->endUndo(*m_world);
+        }
+        ImGui::EndPopup();
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+bool HierarchyPanel::hasChildren(ECS::Entity entity) const {
+    bool found = false;
+    ECS::ComponentQuery childQ;
+    childQ.with<Scene::Parent>();
+    m_world->forEach<Scene::Parent>(childQ, [&](ECS::Entity, Scene::Parent& p) {
+        if (p.parent == entity) found = true;
+    });
+    return found;
+}
+
+void HierarchyPanel::renderChildren(ECS::Entity parent) {
+    ECS::ComponentQuery childQ;
+    childQ.with<Scene::Parent>();
+    m_world->forEach<Scene::Parent>(childQ, [&](ECS::Entity child, Scene::Parent& p) {
+        if (p.parent == parent) {
+            renderEntityNode(child);
+        }
+    });
+}
+
+} // namespace Caffeine::Editor
+
+#endif // CF_HAS_IMGUI

--- a/src/editor/HierarchyPanel.hpp
+++ b/src/editor/HierarchyPanel.hpp
@@ -17,171 +17,37 @@ using namespace Caffeine;
 
 class HierarchyPanel {
 public:
-    HierarchyPanel() = default;
+    explicit HierarchyPanel(EditorContext* context) : m_context(context) {}
 
-    void render(ECS::World& world, EditorContext& ctx) {
-#ifdef CF_HAS_IMGUI
-        if (!m_open) return;
-        if (ImGui::Begin("Hierarchy", &m_open)) {
-            // Toolbar
-            if (ImGui::Button("+", ImVec2(24, 0))) {
-                ctx.beginUndo(EditorCommand::AddEntity, u32_max, world);
-                ECS::Entity e = world.create();
-                setEntityName(world, e, "New Entity");
-                ctx.selectedEntity = e;
-                ctx.endUndo(world);
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Delete", ImVec2(0, 0))) {
-                if (ctx.selectedEntity.isValid()) {
-                    ctx.beginUndo(EditorCommand::RemoveEntity, ctx.selectedEntity.id(), world);
-                    world.destroy(ctx.selectedEntity);
-                    ctx.selectedEntity = ECS::Entity::INVALID;
-                    ctx.endUndo(world);
-                }
-            }
-
-            ImGui::Separator();
-            ImGui::BeginChild("entity_list");
-
-            // Build root list: entities without Parent component, or with Parent::INVALID
-            m_entityCount = 0;
-            ECS::ComponentQuery allQ;
-            world.forEach<NameComponent>(allQ, [&](ECS::Entity e, NameComponent& nc) {
-                m_entities[m_entityCount++] = e;
-            });
-
-            for (u32 i = 0; i < m_entityCount; ++i) {
-                ECS::Entity e = m_entities[i];
-                const char* name = getEntityName(world, e);
-                renderEntityNode(world, e, name, ctx);
-            }
-
-            ImGui::EndChild();
-        }
-        ImGui::End();
-#endif
-    }
+    void render(ECS::World& world, EditorContext& ctx);
+    void onImGuiRender();
 
     bool isOpen() const { return m_open; }
     void close() { m_open = false; }
     void open()  { m_open = true; }
 
+    EditorContext* context() const { return m_context; }
+    void setContext(EditorContext* ctx) { m_context = ctx; }
+    void setWorld(ECS::World* world) { m_world = world; }
+
 private:
-#ifdef CF_HAS_IMGUI
-    void renderEntityNode(ECS::World& world, ECS::Entity entity, const char* name, EditorContext& ctx) {
-        ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow
-                                 | ImGuiTreeNodeFlags_SpanAvailWidth;
-        if (ctx.selectedEntity == entity) {
-            flags |= ImGuiTreeNodeFlags_Selected;
-        }
+    void renderSearchBar();
+    void renderToolbar();
+    void renderEntityNode(ECS::Entity entity);
+    void renderEmptyContextMenu();
+    void handleDeleteKey();
 
-        // Check for children
-        bool hasChildren = false;
-        ECS::ComponentQuery childQ;
-        childQ.with<Scene::Parent>();
-        world.forEach<Scene::Parent>(childQ, [&](ECS::Entity, Scene::Parent& p) {
-            if (p.parent == entity) hasChildren = true;
-        });
+    bool hasChildren(ECS::Entity entity) const;
+    void renderChildren(ECS::Entity parent);
 
-        if (!hasChildren) {
-            flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
-        }
-
-        bool open = ImGui::TreeNodeEx((void*)(uintptr_t)entity.id(), flags, "%s", name);
-
-        if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen()) {
-            ctx.selectedEntity = entity;
-        }
-
-        // Drag-drop target for reparenting
-        if (ImGui::BeginDragDropTarget()) {
-            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ENTITY_DRAG")) {
-                ECS::Entity dragged(*(u32*)payload->Data, &world);
-                if (dragged != entity) {
-                    ctx.beginUndo(EditorCommand::MoveEntity, dragged.id(), world);
-                    auto& parentComp = world.add<Scene::Parent>(dragged);
-                    parentComp.parent = entity;
-                    parentComp.dirty = true;
-                    ctx.endUndo(world);
-                }
-            }
-            ImGui::EndDragDropTarget();
-        }
-
-        // Drag source
-        if (ImGui::BeginDragDropSource()) {
-            u32 eid = entity.id();
-            ImGui::SetDragDropPayload("ENTITY_DRAG", &eid, sizeof(u32));
-            ImGui::Text("%s", name);
-            ImGui::EndDragDropSource();
-        }
-
-        // Context menu
-        if (ImGui::BeginPopupContextItem()) {
-            if (ImGui::MenuItem("Rename")) { m_renaming = entity; }
-            if (ImGui::MenuItem("Create Child")) {
-                ctx.beginUndo(EditorCommand::AddEntity, u32_max, world);
-                ECS::Entity child = world.create();
-                setEntityName(world, child, "Child");
-                auto& parentComp = world.add<Scene::Parent>(child);
-                parentComp.parent = entity;
-                parentComp.dirty = true;
-                ctx.endUndo(world);
-            }
-            if (ImGui::MenuItem("Delete")) {
-                ctx.beginUndo(EditorCommand::RemoveEntity, entity.id(), world);
-                world.destroy(entity);
-                if (ctx.selectedEntity == entity) ctx.selectedEntity = ECS::Entity::INVALID;
-                ctx.endUndo(world);
-            }
-            ImGui::EndPopup();
-        }
-
-        if (hasChildren && open) {
-            // Render children recursively
-            ECS::ComponentQuery childQ2;
-            childQ2.with<Scene::Parent>();
-            world.forEach<Scene::Parent>(childQ2, [&](ECS::Entity child, Scene::Parent& p) {
-                if (p.parent == entity) {
-                    const char* childName = getEntityName(world, child);
-                    renderEntityNode(world, child, childName, ctx);
-                }
-            });
-            ImGui::TreePop();
-        }
-
-        // Inline rename popup
-        if (m_renaming == entity) {
-            ImGui::OpenPopup("##rename");
-            if (ImGui::BeginPopup("##rename")) {
-                ImGui::Text("Rename: %s", name);
-                char buf[64];
-                const char* curName = getEntityName(world, entity);
-                strncpy(buf, curName, sizeof(buf));
-                buf[sizeof(buf) - 1] = '\0';
-                if (ImGui::InputText("##rename_input", buf, sizeof(buf),
-                                     ImGuiInputTextFlags_EnterReturnsTrue)) {
-                    ctx.beginUndo(EditorCommand::SetField, entity.id(), world);
-                    setEntityName(world, entity, buf);
-                    ctx.endUndo(world);
-                    m_renaming = ECS::Entity::INVALID;
-                    ImGui::CloseCurrentPopup();
-                }
-                if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
-                    m_renaming = ECS::Entity::INVALID;
-                    ImGui::CloseCurrentPopup();
-                }
-                ImGui::EndPopup();
-            } else {
-                m_renaming = ECS::Entity::INVALID;
-            }
-        }
-    }
-#endif
+    EditorContext* m_context = nullptr;
+    ECS::World*    m_world   = nullptr;
 
     bool m_open = true;
-    ECS::Entity m_entities[4096];
+    char m_searchFilter[256] = "";
+
+    static constexpr u32 MAX_VISIBLE = 4096;
+    ECS::Entity m_entities[MAX_VISIBLE];
     u32 m_entityCount = 0;
     ECS::Entity m_renaming = ECS::Entity::INVALID;
 };

--- a/src/editor/SceneEditor.hpp
+++ b/src/editor/SceneEditor.hpp
@@ -25,7 +25,7 @@ using namespace Caffeine;
 
 class SceneEditor {
 public:
-    SceneEditor() = default;
+    SceneEditor() : m_hierarchy(&m_ctx) {}
 
 #ifdef CF_HAS_SDL3
     bool init(RHI::RenderDevice* device, Assets::AssetManager* assetManager,

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -277,3 +277,38 @@ TEST_CASE("NameComponent - Multiple Entities", "[editor][name]") {
     REQUIRE(strcmp(getEntityName(world, e2), "Enemy") == 0);
     REQUIRE(strcmp(getEntityName(world, e3), "NPC") == 0);
 }
+
+// ============================================================================
+// HierarchyPanel Tests
+// ============================================================================
+
+TEST_CASE("HierarchyPanel - Constructor stores context", "[editor][hierarchy]") {
+    EditorContext ctx;
+    HierarchyPanel panel(&ctx);
+    REQUIRE(panel.context() == &ctx);
+}
+
+TEST_CASE("HierarchyPanel - Default state", "[editor][hierarchy]") {
+    EditorContext ctx;
+    HierarchyPanel panel(&ctx);
+    REQUIRE(panel.isOpen() == true);
+}
+
+TEST_CASE("HierarchyPanel - setContext updates pointer", "[editor][hierarchy]") {
+    EditorContext ctx1;
+    EditorContext ctx2;
+    HierarchyPanel panel(&ctx1);
+    REQUIRE(panel.context() == &ctx1);
+    panel.setContext(&ctx2);
+    REQUIRE(panel.context() == &ctx2);
+}
+
+TEST_CASE("HierarchyPanel - close and open", "[editor][hierarchy]") {
+    EditorContext ctx;
+    HierarchyPanel panel(&ctx);
+    REQUIRE(panel.isOpen() == true);
+    panel.close();
+    REQUIRE(panel.isOpen() == false);
+    panel.open();
+    REQUIRE(panel.isOpen() == true);
+}

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -9,6 +9,7 @@
 #include "../src/editor/ConsoleWindow.hpp"
 #include "../src/editor/ProfilerWindow.hpp"
 #include "../src/editor/StatsOverlay.hpp"
+#include "../src/editor/HierarchyPanel.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;


### PR DESCRIPTION
## Summary

Implement a dedicated `HierarchyPanel` class (issue #76, Milestone M1) with its own `.cpp` file, refactored from the previous inline header.

### Changes

**New file:**
- `src/editor/HierarchyPanel.cpp` — Full ImGui rendering implementation

**Modified files:**
- `src/editor/HierarchyPanel.hpp` — Refactored from 189-line inline-heavy header to clean class declaration; now stores `EditorContext*` and `World*` as members
- `src/editor/SceneEditor.hpp` — `SceneEditor()` constructor passes `&m_ctx` to `HierarchyPanel`
- `CMakeLists.txt` — Added `HierarchyPanel.cpp` to doppio executable sources
- `tests/test_editor.cpp` — Added 4 tests for panel construction/state

### Features per acceptance criteria
- ✅ Root entities in tree; children indented under parent
- ✅ Click selects entity in EditorContext
- ✅ Right-click empty space → `Create Empty Entity`
- ✅ Delete key with focus removes selected entity
- ✅ Search filter (case-insensitive substring match)
- ✅ Entity context menu: Rename, Create Child, Delete
- ✅ Drag-and-drop reparenting
- ✅ All operations wrapped in beginUndo/endUndo