### PR TITLE
refactor(editor): split SceneViewport into .hpp/.cpp with member-based design (RF6.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
     add_executable(doppio
         apps/doppio/main.cpp
         src/editor/HierarchyPanel.cpp
+        src/editor/SceneViewport.cpp
     )
     target_link_libraries(doppio PRIVATE caffeine-core ImGui)
     target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/editor/SceneViewport.cpp
+++ b/src/editor/SceneViewport.cpp
@@ -1,0 +1,244 @@
+#include "editor/SceneViewport.hpp"
+
+#ifdef CF_HAS_IMGUI
+
+namespace Caffeine::Editor {
+
+// ── Init / Shutdown ───────────────────────────────────────────────
+
+#ifdef CF_HAS_SDL3
+bool SceneViewport::init(RHI::RenderDevice* device, Config cfg) {
+    m_device = device;
+    m_config = cfg;
+
+    RHI::TextureDesc colorDesc;
+    colorDesc.width  = cfg.width;
+    colorDesc.height = cfg.height;
+    colorDesc.format = RHI::TextureFormat::R8G8B8A8_UNORM;
+    colorDesc.usage  = RHI::TextureUsage::Sampler | RHI::TextureUsage::ColorTarget;
+    m_colorTarget = device->createTexture(colorDesc);
+
+    RHI::TextureDesc depthDesc;
+    depthDesc.width  = cfg.width;
+    depthDesc.height = cfg.height;
+    depthDesc.format = RHI::TextureFormat::D32_FLOAT;
+    depthDesc.usage  = RHI::TextureUsage::DepthStencil;
+    m_depthTarget = device->createTexture(depthDesc);
+
+    m_initialized = (m_colorTarget != nullptr);
+    return m_initialized;
+}
+
+void SceneViewport::shutdown() {
+    if (!m_initialized || !m_device) return;
+    m_device->destroyTexture(m_colorTarget);
+    m_device->destroyTexture(m_depthTarget);
+    m_colorTarget = nullptr;
+    m_depthTarget = nullptr;
+    m_initialized = false;
+}
+#endif
+
+// ── Main render entry point ───────────────────────────────────────
+
+void SceneViewport::render(ECS::World& world, EditorContext& ctx
+#ifdef CF_HAS_SDL3
+                            , Render::Camera2D& editorCamera
+#endif
+                           ) {
+    if (!m_open) return;
+
+#ifdef CF_HAS_SDL3
+    // Use ImGui::Image to display the offscreen framebuffer
+    ImVec2 viewportSize = ImGui::GetContentRegionAvail();
+    if (viewportSize.x < 1 || viewportSize.y < 1) return;
+
+    // Show the framebuffer texture as an ImGui image
+    ImGui::Image((ImTextureID)(intptr_t)m_colorTarget->handle, viewportSize);
+#else
+    // Without SDL3, show a placeholder
+    ImVec2 viewportSize = ImGui::GetContentRegionAvail();
+    if (viewportSize.x < 1 || viewportSize.y < 1) return;
+    ImGui::Dummy(viewportSize);
+#endif
+
+    bool hovered = ImGui::IsItemHovered();
+    bool focused = ImGui::IsWindowFocused();
+
+    if (hovered) {
+        // Handle gizmo hotkeys
+        if (focused) {
+            if (ImGui::IsKeyPressed(ImGuiKey_W)) ctx.gizmoMode = EditorContext::GizmoMode::Translate;
+            if (ImGui::IsKeyPressed(ImGuiKey_E)) ctx.gizmoMode = EditorContext::GizmoMode::Rotate;
+            if (ImGui::IsKeyPressed(ImGuiKey_R)) ctx.gizmoMode = EditorContext::GizmoMode::Scale;
+            if (ImGui::IsKeyPressed(ImGuiKey_Q)) ctx.gizmoMode = EditorContext::GizmoMode::None;
+        }
+
+        if (ctx.selectedEntity.isValid() && ctx.gizmoMode != EditorContext::GizmoMode::None) {
+            bool dragging = ImGui::IsMouseDragging(ImGuiMouseButton_Left);
+            if (dragging && !m_gizmoDragging) {
+                ctx.beginUndo(EditorCommand::SetField, ctx.selectedEntity.id(), world);
+                m_gizmoDragging = true;
+            }
+            if (m_gizmoDragging) {
+                handleGizmoInput(world, ctx, viewportSize);
+            }
+            if (!dragging && m_gizmoDragging) {
+                ctx.endUndo(world);
+                m_gizmoDragging = false;
+            }
+        }
+    }
+
+    // Draw gizmo overlay and grid info
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    ImVec2 origin = ImGui::GetItemRectMin();
+
+    // Grid overlay text
+    if (m_config.grid) {
+        char modeStr[16];
+        switch (ctx.gizmoMode) {
+            case EditorContext::GizmoMode::Translate: strcpy(modeStr, "Translate"); break;
+            case EditorContext::GizmoMode::Rotate:    strcpy(modeStr, "Rotate"); break;
+            case EditorContext::GizmoMode::Scale:     strcpy(modeStr, "Scale"); break;
+            default: strcpy(modeStr, "Select"); break;
+        }
+        char buf[64];
+        snprintf(buf, sizeof(buf), "Gizmo: %s [W/E/R]  Grid: %s", modeStr, m_config.grid ? "ON" : "OFF");
+        drawList->AddText(ImVec2(origin.x + 8, origin.y + 8), IM_COL32(200, 200, 200, 200), buf);
+    }
+
+    // Draw gizmo handles for selected entity
+    if (ctx.selectedEntity.isValid() && hovered) {
+        drawGizmo(world, ctx, origin, viewportSize);
+    }
+
+    // Handle viewport pan (middle mouse)
+    if (hovered && ImGui::IsMouseDragging(ImGuiMouseButton_Middle)) {
+        ImVec2 delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Middle);
+        ctx.viewportPanX += delta.x;
+        ctx.viewportPanY += delta.y;
+        ImGui::ResetMouseDragDelta(ImGuiMouseButton_Middle);
+    }
+
+    // Handle viewport zoom (scroll)
+    if (hovered) {
+        float scroll = ImGui::GetIO().MouseWheel;
+        if (scroll != 0) {
+            ctx.viewportZoom *= (scroll > 0) ? 1.1f : 0.9f;
+            if (ctx.viewportZoom < 0.1f) ctx.viewportZoom = 0.1f;
+            if (ctx.viewportZoom > 10.0f) ctx.viewportZoom = 10.0f;
+        }
+    }
+}
+
+// ── Gizmo drawing ─────────────────────────────────────────────────
+
+void SceneViewport::drawGizmo(ECS::World& world, EditorContext& ctx, ImVec2 origin, ImVec2 viewportSize) {
+    if (!ctx.selectedEntity.isValid()) return;
+
+    auto* pos = world.get<ECS::Position2D>(ctx.selectedEntity);
+    if (!pos) return;
+
+    // Convert world position to screen position
+    f32 worldToScreen = ctx.viewportZoom * 50.0f;
+    ImVec2 screenPos(
+        origin.x + viewportSize.x * 0.5f + (pos->x + ctx.viewportPanX / worldToScreen) * worldToScreen,
+        origin.y + viewportSize.y * 0.5f + (pos->y + ctx.viewportPanY / worldToScreen) * worldToScreen
+    );
+
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    float handleLen = 30.0f * ctx.viewportZoom;
+
+    switch (ctx.gizmoMode) {
+        case EditorContext::GizmoMode::Translate: {
+            dl->AddLine(screenPos, ImVec2(screenPos.x + handleLen, screenPos.y),
+                        IM_COL32(255, 50, 50, 255), 3.0f);
+            dl->AddTriangleFilled(
+                ImVec2(screenPos.x + handleLen + 8, screenPos.y),
+                ImVec2(screenPos.x + handleLen, screenPos.y - 5),
+                ImVec2(screenPos.x + handleLen, screenPos.y + 5),
+                IM_COL32(255, 50, 50, 255));
+            dl->AddLine(screenPos, ImVec2(screenPos.x, screenPos.y - handleLen),
+                        IM_COL32(50, 255, 50, 255), 3.0f);
+            dl->AddTriangleFilled(
+                ImVec2(screenPos.x, screenPos.y - handleLen - 8),
+                ImVec2(screenPos.x - 5, screenPos.y - handleLen),
+                ImVec2(screenPos.x + 5, screenPos.y - handleLen),
+                IM_COL32(50, 255, 50, 255));
+            break;
+        }
+        case EditorContext::GizmoMode::Rotate: {
+            dl->AddCircle(screenPos, handleLen, IM_COL32(255, 200, 50, 255), 32, 2.0f);
+            dl->AddLine(screenPos,
+                        ImVec2(screenPos.x + handleLen, screenPos.y),
+                        IM_COL32(255, 200, 50, 255), 2.0f);
+            break;
+        }
+        case EditorContext::GizmoMode::Scale: {
+            dl->AddLine(screenPos, ImVec2(screenPos.x + handleLen, screenPos.y),
+                        IM_COL32(100, 200, 255, 255), 2.0f);
+            dl->AddRectFilled(
+                ImVec2(screenPos.x + handleLen - 5, screenPos.y - 5),
+                ImVec2(screenPos.x + handleLen + 5, screenPos.y + 5),
+                IM_COL32(100, 200, 255, 255));
+            dl->AddLine(screenPos, ImVec2(screenPos.x, screenPos.y - handleLen),
+                        IM_COL32(50, 255, 100, 255), 2.0f);
+            dl->AddRectFilled(
+                ImVec2(screenPos.x - 5, screenPos.y - handleLen - 5),
+                ImVec2(screenPos.x + 5, screenPos.y - handleLen + 5),
+                IM_COL32(50, 255, 100, 255));
+            break;
+        }
+        case EditorContext::GizmoMode::None:
+            dl->AddCircle(screenPos, 6, IM_COL32(255, 255, 255, 180), 12, 2.0f);
+            break;
+    }
+}
+
+// ── Gizmo input handling ──────────────────────────────────────────
+
+void SceneViewport::handleGizmoInput(ECS::World& world, EditorContext& ctx, ImVec2 viewportSize) {
+    if (!ctx.selectedEntity.isValid()) return;
+
+    if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+        ImVec2 delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
+
+        f32 sensitivity = 1.0f / (ctx.viewportZoom * 50.0f);
+
+        auto* pos = world.get<ECS::Position2D>(ctx.selectedEntity);
+        bool hadPos = (pos != nullptr);
+
+        if (!hadPos) {
+            pos = &world.add<ECS::Position2D>(ctx.selectedEntity, 0.0f, 0.0f);
+        }
+
+        switch (ctx.gizmoMode) {
+            case EditorContext::GizmoMode::Translate:
+                pos->x += delta.x * sensitivity;
+                pos->y -= delta.y * sensitivity;
+                break;
+            case EditorContext::GizmoMode::Rotate: {
+                auto& rot = world.add<ECS::Rotation>(ctx.selectedEntity);
+                rot.angle += delta.x * 0.01f;
+                break;
+            }
+            case EditorContext::GizmoMode::Scale: {
+                auto& scl = world.add<ECS::Scale2D>(ctx.selectedEntity, 1.0f, 1.0f);
+                scl.x *= 1.0f + delta.x * 0.005f;
+                scl.y *= 1.0f + delta.y * 0.005f;
+                if (scl.x < 0.01f) scl.x = 0.01f;
+                if (scl.y < 0.01f) scl.y = 0.01f;
+                break;
+            }
+            case EditorContext::GizmoMode::None: break;
+        }
+
+        ctx.isDirty = true;
+        ImGui::ResetMouseDragDelta(ImGuiMouseButton_Left);
+    }
+}
+
+} // namespace Caffeine::Editor
+
+#endif // CF_HAS_IMGUI

--- a/src/editor/SceneViewport.hpp
+++ b/src/editor/SceneViewport.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "core/Types.hpp"
 #include "ecs/World.hpp"
-#include "ecs/Components.hpp"
 #include "ecs/Entity.hpp"
+#include "ecs/Components.hpp"
 #include "scene/SceneComponents.hpp"
 #include "render/Camera2D.hpp"
 #include "math/Math.hpp"
@@ -37,136 +37,16 @@ public:
     SceneViewport() = default;
 
 #ifdef CF_HAS_SDL3
-    bool init(RHI::RenderDevice* device, Config cfg = {}) {
-        m_device = device;
-        m_config = cfg;
-
-        RHI::TextureDesc colorDesc;
-        colorDesc.width  = cfg.width;
-        colorDesc.height = cfg.height;
-        colorDesc.format = RHI::TextureFormat::R8G8B8A8_UNORM;
-        colorDesc.usage  = RHI::TextureUsage::Sampler | RHI::TextureUsage::ColorTarget;
-        m_colorTarget = device->createTexture(colorDesc);
-
-        RHI::TextureDesc depthDesc;
-        depthDesc.width  = cfg.width;
-        depthDesc.height = cfg.height;
-        depthDesc.format = RHI::TextureFormat::D32_FLOAT;
-        depthDesc.usage  = RHI::TextureUsage::DepthStencil;
-        m_depthTarget = device->createTexture(depthDesc);
-
-        m_initialized = (m_colorTarget != nullptr);
-        return m_initialized;
-    }
-
-    void shutdown() {
-        if (!m_initialized || !m_device) return;
-        m_device->destroyTexture(m_colorTarget);
-        m_device->destroyTexture(m_depthTarget);
-        m_colorTarget = nullptr;
-        m_depthTarget = nullptr;
-        m_initialized = false;
-    }
+    bool init(RHI::RenderDevice* device, Config cfg = {});
+    void shutdown();
+    RHI::Texture* colorTarget() const { return m_colorTarget; }
 #endif
 
     void render(ECS::World& world, EditorContext& ctx
 #ifdef CF_HAS_SDL3
                 , Render::Camera2D& editorCamera
 #endif
-               ) {
-#ifdef CF_HAS_IMGUI
-        if (!m_open) return;
-
-#ifdef CF_HAS_SDL3
-        // Use ImGui::Image to display the offscreen framebuffer
-        ImVec2 viewportSize = ImGui::GetContentRegionAvail();
-        if (viewportSize.x < 1 || viewportSize.y < 1) return;
-
-        // Show the framebuffer texture as an ImGui image
-        // SDL_GPUTexture* is passed as ImTextureID
-        ImGui::Image((ImTextureID)(intptr_t)m_colorTarget->handle, viewportSize);
-#else
-        // Without SDL3, show a placeholder
-        ImVec2 viewportSize = ImGui::GetContentRegionAvail();
-        if (viewportSize.x < 1 || viewportSize.y < 1) return;
-        ImGui::Dummy(viewportSize);
-#endif
-
-        bool hovered = ImGui::IsItemHovered();
-        bool focused = ImGui::IsWindowFocused();
-
-        if (hovered) {
-            // Handle gizmo hotkeys
-            if (focused) {
-                if (ImGui::IsKeyPressed(ImGuiKey_W)) ctx.gizmoMode = EditorContext::GizmoMode::Translate;
-                if (ImGui::IsKeyPressed(ImGuiKey_E)) ctx.gizmoMode = EditorContext::GizmoMode::Rotate;
-                if (ImGui::IsKeyPressed(ImGuiKey_R)) ctx.gizmoMode = EditorContext::GizmoMode::Scale;
-                if (ImGui::IsKeyPressed(ImGuiKey_Q)) ctx.gizmoMode = EditorContext::GizmoMode::None;
-            }
-
-            if (ctx.selectedEntity.isValid() && ctx.gizmoMode != EditorContext::GizmoMode::None) {
-                bool dragging = ImGui::IsMouseDragging(ImGuiMouseButton_Left);
-                if (dragging && !m_gizmoDragging) {
-                    ctx.beginUndo(EditorCommand::SetField, ctx.selectedEntity.id(), world);
-                    m_gizmoDragging = true;
-                }
-                if (m_gizmoDragging) {
-                    handleGizmoInput(world, ctx, viewportSize);
-                }
-                if (!dragging && m_gizmoDragging) {
-                    ctx.endUndo(world);
-                    m_gizmoDragging = false;
-                }
-            }
-        }
-
-        // Draw gizmo overlay and grid info
-        ImDrawList* drawList = ImGui::GetWindowDrawList();
-        ImVec2 origin = ImGui::GetItemRectMin();
-
-        // Grid overlay text
-        if (m_config.grid) {
-            char modeStr[16];
-            switch (ctx.gizmoMode) {
-                case EditorContext::GizmoMode::Translate: strcpy(modeStr, "Translate"); break;
-                case EditorContext::GizmoMode::Rotate:    strcpy(modeStr, "Rotate"); break;
-                case EditorContext::GizmoMode::Scale:     strcpy(modeStr, "Scale"); break;
-                default: strcpy(modeStr, "Select"); break;
-            }
-            char buf[64];
-            snprintf(buf, sizeof(buf), "Gizmo: %s [W/E/R]  Grid: %s", modeStr, m_config.grid ? "ON" : "OFF");
-            drawList->AddText(ImVec2(origin.x + 8, origin.y + 8), IM_COL32(200, 200, 200, 200), buf);
-        }
-
-        // Draw gizmo handles for selected entity
-        if (ctx.selectedEntity.isValid() && hovered) {
-            drawGizmo(world, ctx, origin, viewportSize);
-        }
-
-        // Handle viewport pan (middle mouse)
-        if (hovered && ImGui::IsMouseDragging(ImGuiMouseButton_Middle)) {
-            ImVec2 delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Middle);
-            ctx.viewportPanX += delta.x;
-            ctx.viewportPanY += delta.y;
-            ImGui::ResetMouseDragDelta(ImGuiMouseButton_Middle);
-        }
-
-        // Handle viewport zoom (scroll)
-        if (hovered) {
-            float scroll = ImGui::GetIO().MouseWheel;
-            if (scroll != 0) {
-                ctx.viewportZoom *= (scroll > 0) ? 1.1f : 0.9f;
-                if (ctx.viewportZoom < 0.1f) ctx.viewportZoom = 0.1f;
-                if (ctx.viewportZoom > 10.0f) ctx.viewportZoom = 10.0f;
-            }
-        }
-
-#endif
-    }
-
-#ifdef CF_HAS_SDL3
-    RHI::Texture* colorTarget() const { return m_colorTarget; }
-#endif
+               );
 
     bool isOpen() const { return m_open; }
     void close() { m_open = false; }
@@ -174,115 +54,8 @@ public:
 
 private:
 #ifdef CF_HAS_IMGUI
-    void drawGizmo(ECS::World& world, EditorContext& ctx, ImVec2 origin, ImVec2 viewportSize) {
-        if (!ctx.selectedEntity.isValid()) return;
-
-        auto* pos = world.get<ECS::Position2D>(ctx.selectedEntity);
-        if (!pos) return;
-
-        // Convert world position to screen position
-        f32 worldToScreen = ctx.viewportZoom * 50.0f; // pixels per unit
-        ImVec2 screenPos(
-            origin.x + viewportSize.x * 0.5f + (pos->x + ctx.viewportPanX / worldToScreen) * worldToScreen,
-            origin.y + viewportSize.y * 0.5f + (pos->y + ctx.viewportPanY / worldToScreen) * worldToScreen
-        );
-
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-        float handleLen = 30.0f * ctx.viewportZoom;
-
-        switch (ctx.gizmoMode) {
-            case EditorContext::GizmoMode::Translate: {
-                // X axis (red)
-                dl->AddLine(screenPos, ImVec2(screenPos.x + handleLen, screenPos.y),
-                            IM_COL32(255, 50, 50, 255), 3.0f);
-                dl->AddTriangleFilled(
-                    ImVec2(screenPos.x + handleLen + 8, screenPos.y),
-                    ImVec2(screenPos.x + handleLen, screenPos.y - 5),
-                    ImVec2(screenPos.x + handleLen, screenPos.y + 5),
-                    IM_COL32(255, 50, 50, 255));
-                // Y axis (green)
-                dl->AddLine(screenPos, ImVec2(screenPos.x, screenPos.y - handleLen),
-                            IM_COL32(50, 255, 50, 255), 3.0f);
-                dl->AddTriangleFilled(
-                    ImVec2(screenPos.x, screenPos.y - handleLen - 8),
-                    ImVec2(screenPos.x - 5, screenPos.y - handleLen),
-                    ImVec2(screenPos.x + 5, screenPos.y - handleLen),
-                    IM_COL32(50, 255, 50, 255));
-                break;
-            }
-            case EditorContext::GizmoMode::Rotate: {
-                // Circle with angle indicator
-                dl->AddCircle(screenPos, handleLen, IM_COL32(255, 200, 50, 255), 32, 2.0f);
-                dl->AddLine(screenPos,
-                            ImVec2(screenPos.x + handleLen, screenPos.y),
-                            IM_COL32(255, 200, 50, 255), 2.0f);
-                break;
-            }
-            case EditorContext::GizmoMode::Scale: {
-                // X axis (red box)
-                dl->AddLine(screenPos, ImVec2(screenPos.x + handleLen, screenPos.y),
-                            IM_COL32(100, 200, 255, 255), 2.0f);
-                dl->AddRectFilled(
-                    ImVec2(screenPos.x + handleLen - 5, screenPos.y - 5),
-                    ImVec2(screenPos.x + handleLen + 5, screenPos.y + 5),
-                    IM_COL32(100, 200, 255, 255));
-                // Y axis (green box)
-                dl->AddLine(screenPos, ImVec2(screenPos.x, screenPos.y - handleLen),
-                            IM_COL32(50, 255, 100, 255), 2.0f);
-                dl->AddRectFilled(
-                    ImVec2(screenPos.x - 5, screenPos.y - handleLen - 5),
-                    ImVec2(screenPos.x + 5, screenPos.y - handleLen + 5),
-                    IM_COL32(50, 255, 100, 255));
-                break;
-            }
-            case EditorContext::GizmoMode::None:
-                // Selection indicator - small circle
-                dl->AddCircle(screenPos, 6, IM_COL32(255, 255, 255, 180), 12, 2.0f);
-                break;
-        }
-    }
-
-    void handleGizmoInput(ECS::World& world, EditorContext& ctx, ImVec2 viewportSize) {
-        if (!ctx.selectedEntity.isValid()) return;
-
-        // Simple drag handling for entity manipulation
-        if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-            ImVec2 delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
-
-            f32 sensitivity = 1.0f / (ctx.viewportZoom * 50.0f);
-
-            auto* pos = world.get<ECS::Position2D>(ctx.selectedEntity);
-            bool hadPos = (pos != nullptr);
-
-            if (!hadPos) {
-                pos = &world.add<ECS::Position2D>(ctx.selectedEntity, 0.0f, 0.0f);
-            }
-
-            switch (ctx.gizmoMode) {
-                case EditorContext::GizmoMode::Translate:
-                    pos->x += delta.x * sensitivity;
-                    pos->y -= delta.y * sensitivity; // Y is inverted in screen space
-                    break;
-                case EditorContext::GizmoMode::Rotate: {
-                    auto& rot = world.add<ECS::Rotation>(ctx.selectedEntity);
-                    rot.angle += delta.x * 0.01f;
-                    break;
-                }
-                case EditorContext::GizmoMode::Scale: {
-                    auto& scl = world.add<ECS::Scale2D>(ctx.selectedEntity, 1.0f, 1.0f);
-                    scl.x *= 1.0f + delta.x * 0.005f;
-                    scl.y *= 1.0f + delta.y * 0.005f;
-                    if (scl.x < 0.01f) scl.x = 0.01f;
-                    if (scl.y < 0.01f) scl.y = 0.01f;
-                    break;
-                }
-                case EditorContext::GizmoMode::None: break;
-            }
-
-            ctx.isDirty = true;
-            ImGui::ResetMouseDragDelta(ImGuiMouseButton_Left);
-        }
-    }
+    void drawGizmo(ECS::World& world, EditorContext& ctx, ImVec2 origin, ImVec2 viewportSize);
+    void handleGizmoInput(ECS::World& world, EditorContext& ctx, ImVec2 viewportSize);
 #endif
 
     bool m_open = true;

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -10,6 +10,7 @@
 #include "../src/editor/ProfilerWindow.hpp"
 #include "../src/editor/StatsOverlay.hpp"
 #include "../src/editor/HierarchyPanel.hpp"
+#include "../src/editor/SceneViewport.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;
@@ -312,4 +313,22 @@ TEST_CASE("HierarchyPanel - close and open", "[editor][hierarchy]") {
     REQUIRE(panel.isOpen() == false);
     panel.open();
     REQUIRE(panel.isOpen() == true);
+}
+
+// ============================================================================
+// SceneViewport Tests
+// ============================================================================
+
+TEST_CASE("SceneViewport - Default state", "[editor][viewport]") {
+    SceneViewport viewport;
+    REQUIRE(viewport.isOpen() == true);
+}
+
+TEST_CASE("SceneViewport - close and open", "[editor][viewport]") {
+    SceneViewport viewport;
+    REQUIRE(viewport.isOpen() == true);
+    viewport.close();
+    REQUIRE(viewport.isOpen() == false);
+    viewport.open();
+    REQUIRE(viewport.isOpen() == true);
 }


### PR DESCRIPTION
## Summary

Refactors `SceneViewport` from a fully inline 299-line header to a clean `.hpp`/`.cpp` split following the same pattern established by `HierarchyPanel` (PR #84).

### Changes

- **SceneViewport.hpp** — Reduced from 299→56 lines. Clean class declaration with:
  - `Config` struct for viewport settings
  - `init()`/`shutdown()` for RHI texture management (guarded by `CF_HAS_SDL3`)
  - `render()` entry point with conditional compilation for headless mode
  - `isOpen()`/`close()`/`open()` visibility controls
  - Accessor `colorTarget()` for the offscreen texture
  - Private `drawGizmo()` and `handleGizmoInput()` helpers (guarded by `CF_HAS_IMGUI`)
- **SceneViewport.cpp** (new) — 244-line implementation with:
  - Texture creation/destruction via SDL3 RHI
  - ImGui viewport rendering with gizmo overlays (Translate/Rotate/Scale)
  - Middle-mouse pan and scroll zoom
  - Grid info overlay text
  - Undo-wrapped gizmo operations
  - Headless fallback showing `ImGui::Dummy`
- **CMakeLists.txt** — Added `src/editor/SceneViewport.cpp` to doppio executable
- **Tests** — Added SceneViewport state tests (default state, close/open) matching HierarchyPanel test pattern

### Backward Compatibility

Preserves the existing `SceneEditor` integration — `m_viewport.render(world, ctx, editorCamera)` signature unchanged.