### PR TITLE
refactor(editor): split AssetBrowser into .hpp/.cpp with filesystem navigation (RF6.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
         apps/doppio/main.cpp
         src/editor/HierarchyPanel.cpp
         src/editor/SceneViewport.cpp
+        src/editor/AssetBrowser.cpp
     )
     target_link_libraries(doppio PRIVATE caffeine-core ImGui)
     target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/editor/AssetBrowser.cpp
+++ b/src/editor/AssetBrowser.cpp
@@ -1,0 +1,150 @@
+#include "editor/AssetBrowser.hpp"
+
+#ifdef CF_HAS_IMGUI
+
+namespace Caffeine::Editor {
+
+// ── Init / Refresh ───────────────────────────────────────────────
+
+void AssetBrowser::init(const char* rootPath) {
+    m_rootPath = rootPath;
+    m_currentDir = rootPath;
+    refreshDirectory();
+}
+
+void AssetBrowser::refreshDirectory() {
+    m_entries.clear();
+    if (!std::filesystem::exists(m_currentDir)) return;
+
+    for (const auto& entry : std::filesystem::directory_iterator(m_currentDir)) {
+        if (entry.is_directory()) {
+            Entry e;
+            e.path = entry.path();
+            e.type = AssetType::Unknown;
+            strncpy(e.label, entry.path().filename().string().c_str(), sizeof(e.label) - 1);
+            e.label[sizeof(e.label) - 1] = '\0';
+            m_entries.push_back(std::move(e));
+        } else {
+            auto ext = entry.path().extension().string();
+            AssetType type = AssetType::Unknown;
+
+            if (ext == ".caf") {
+                type = AssetType::Scene;
+            } else if (ext == ".png" || ext == ".jpg" || ext == ".tga") {
+                type = AssetType::Texture;
+            } else if (ext == ".wav" || ext == ".ogg" || ext == ".mp3") {
+                type = AssetType::Audio;
+            } else if (ext == ".obj") {
+                type = AssetType::Mesh;
+            }
+
+            Entry e;
+            e.path = entry.path();
+            e.type = type;
+            strncpy(e.label, entry.path().filename().string().c_str(), sizeof(e.label) - 1);
+            e.label[sizeof(e.label) - 1] = '\0';
+            m_entries.push_back(std::move(e));
+        }
+    }
+}
+
+// ── Icon helper ──────────────────────────────────────────────────
+
+const char* AssetBrowser::iconForType(AssetType type) {
+    switch (type) {
+        case AssetType::Texture: return "[T]";
+        case AssetType::Audio:   return "[A]";
+        case AssetType::Mesh:    return "[M]";
+        case AssetType::Scene:   return "[S]";
+        default:                 return "[ ]";
+    }
+}
+
+// ── Main render ──────────────────────────────────────────────────
+
+void AssetBrowser::render(EditorContext& ctx) {
+    if (!m_open) return;
+    if (ImGui::Begin("Asset Browser", &m_open)) {
+
+        // Breadcrumb + back button
+        if (ImGui::Button("<- Back") && m_currentDir.has_parent_path()) {
+            m_currentDir = m_currentDir.parent_path();
+            refreshDirectory();
+        }
+        ImGui::SameLine();
+        std::string dirName = m_currentDir.filename().string();
+        if (dirName.empty()) dirName = m_rootPath;
+        ImGui::TextUnformatted(dirName.c_str());
+        ImGui::Separator();
+
+        ImGui::BeginChild("asset_grid", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()));
+
+        int cols = std::max(1, static_cast<int>(ImGui::GetContentRegionAvail().x / 100.0f));
+        ImGui::Columns(cols, nullptr, false);
+
+        for (usize i = 0; i < m_entries.size(); ++i) {
+            auto& entry = m_entries[i];
+
+            bool isDir = std::filesystem::is_directory(entry.path);
+
+            ImGui::BeginGroup();
+            if (isDir) {
+                ImGui::Text("[dir]");
+            } else {
+                ImGui::Text("%s", iconForType(entry.type));
+            }
+            ImGui::TextUnformatted(entry.label);
+
+            if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
+                m_selectedEntry = static_cast<int>(i);
+            }
+
+            if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                if (isDir) {
+                    m_currentDir = entry.path;
+                    refreshDirectory();
+                    ImGui::EndGroup();
+                    break;
+                }
+            }
+
+            if (!isDir && ImGui::BeginDragDropSource()) {
+                std::string pathStr = entry.path.string();
+                ImGui::SetDragDropPayload("ASSET_PATH", pathStr.c_str(), pathStr.size() + 1);
+                ImGui::Text("%s", entry.label);
+                ImGui::EndDragDropSource();
+            }
+
+            if (m_selectedEntry == static_cast<int>(i) && ImGui::IsItemHovered()) {
+                ImGui::GetWindowDrawList()->AddRect(
+                    ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                    IM_COL32(255, 255, 0, 100));
+            }
+
+            ImGui::EndGroup();
+            ImGui::NextColumn();
+        }
+
+        ImGui::Columns(1);
+        ImGui::EndChild();
+    }
+    ImGui::End();
+}
+
+// ── Drag-drop target ─────────────────────────────────────────────
+
+std::optional<std::filesystem::path> AssetBrowser::getDroppedAsset() const {
+    if (ImGui::BeginDragDropTarget()) {
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_PATH")) {
+            std::filesystem::path path(static_cast<const char*>(payload->Data));
+            ImGui::EndDragDropTarget();
+            return path;
+        }
+        ImGui::EndDragDropTarget();
+    }
+    return {};
+}
+
+} // namespace Caffeine::Editor
+
+#endif // CF_HAS_IMGUI

--- a/src/editor/AssetBrowser.hpp
+++ b/src/editor/AssetBrowser.hpp
@@ -22,155 +22,24 @@ class AssetBrowser {
 public:
     struct Entry {
         std::filesystem::path     path;
-        Assets::AssetType         type;
+        AssetType                 type;
         char                      label[64];
     };
 
     AssetBrowser() = default;
 
-    void init(const char* rootPath) {
-        m_rootPath = rootPath;
-        m_currentDir = rootPath;
-        refreshDirectory();
-    }
-
-    void refreshDirectory() {
-        m_entries.clear();
-        if (!std::filesystem::exists(m_currentDir)) return;
-
-        for (const auto& entry : std::filesystem::directory_iterator(m_currentDir)) {
-            if (entry.is_directory()) {
-                Entry e;
-                e.path = entry.path();
-                e.type = Assets::AssetType::Unknown;
-                strncpy(e.label, entry.path().filename().string().c_str(), sizeof(e.label) - 1);
-                e.label[sizeof(e.label) - 1] = '\0';
-                m_entries.push_back(std::move(e));
-            } else {
-                auto ext = entry.path().extension().string();
-                Assets::AssetType type = Assets::AssetType::Unknown;
-                if (ext == ".caf" || ext == ".png" || ext == ".jpg") {
-                    type = Assets::AssetType::Texture;
-                } else if (ext == ".wav" || ext == ".ogg" || ext == ".mp3") {
-                    type = Assets::AssetType::Audio;
-                } else if (ext == ".obj") {
-                    type = Assets::AssetType::Mesh;
-                }
-
-                Entry e;
-                e.path = entry.path();
-                e.type = type;
-                strncpy(e.label, entry.path().filename().string().c_str(), sizeof(e.label) - 1);
-                e.label[sizeof(e.label) - 1] = '\0';
-                m_entries.push_back(std::move(e));
-            }
-        }
-    }
-
-    const char* iconForType(Assets::AssetType type) {
-        switch (type) {
-            case Assets::AssetType::Texture: return "[T]";
-            case Assets::AssetType::Audio:   return "[A]";
-            case Assets::AssetType::Mesh:    return "[M]";
-            case Assets::AssetType::Scene:   return "[S]";
-            default:                         return "[ ]";
-        }
-    }
-
-    void render(EditorContext& ctx) {
-#ifdef CF_HAS_IMGUI
-        if (!m_open) return;
-        if (ImGui::Begin("Asset Browser", &m_open)) {
-
-            // Breadcrumb + back button
-            if (ImGui::Button("<- Back") && m_currentDir.has_parent_path()) {
-                m_currentDir = m_currentDir.parent_path();
-                refreshDirectory();
-            }
-            ImGui::SameLine();
-            std::string dirName = m_currentDir.filename().string();
-            if (dirName.empty()) dirName = m_rootPath;
-            ImGui::TextUnformatted(dirName.c_str());
-            ImGui::Separator();
-
-            ImGui::BeginChild("asset_grid", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()));
-
-            int cols = std::max(1, static_cast<int>(ImGui::GetContentRegionAvail().x / 100.0f));
-            ImGui::Columns(cols, nullptr, false);
-
-            for (usize i = 0; i < m_entries.size(); ++i) {
-                auto& entry = m_entries[i];
-
-                bool isDir = std::filesystem::is_directory(entry.path);
-
-                ImGui::BeginGroup();
-                if (isDir) {
-                    ImGui::Text("[dir]");
-                } else {
-                    ImGui::Text("%s", iconForType(entry.type));
-                }
-                ImGui::TextUnformatted(entry.label);
-
-                // Click to select
-                if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
-                    m_selectedEntry = static_cast<int>(i);
-                }
-
-                // Double-click to navigate (folder) or select asset
-                if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
-                    if (isDir) {
-                        m_currentDir = entry.path;
-                        refreshDirectory();
-                        ImGui::EndGroup();
-                        break; // columns are broken after directory change
-                    }
-                }
-
-                // Drag-drop source for assets
-                if (!isDir && ImGui::BeginDragDropSource()) {
-                    std::string pathStr = entry.path.string();
-                    ImGui::SetDragDropPayload("ASSET_PATH", pathStr.c_str(), pathStr.size() + 1);
-                    ImGui::Text("%s", entry.label);
-                    ImGui::EndDragDropSource();
-                }
-
-                // Selection highlight
-                if (m_selectedEntry == static_cast<int>(i) && ImGui::IsItemHovered()) {
-                    ImGui::GetWindowDrawList()->AddRect(
-                        ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
-                        IM_COL32(255, 255, 0, 100));
-                }
-
-                ImGui::EndGroup();
-                ImGui::NextColumn();
-            }
-
-            ImGui::Columns(1);
-            ImGui::EndChild();
-        }
-        ImGui::End();
-#endif
-    }
-
-    std::optional<std::filesystem::path> getDroppedAsset() const {
-#ifdef CF_HAS_IMGUI
-        if (ImGui::BeginDragDropTarget()) {
-            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_PATH")) {
-                std::filesystem::path path(static_cast<const char*>(payload->Data));
-                ImGui::EndDragDropTarget();
-                return path;
-            }
-            ImGui::EndDragDropTarget();
-        }
-#endif
-        return {};
-    }
+    void init(const char* rootPath);
+    void refreshDirectory();
+    void render(EditorContext& ctx);
+    std::optional<std::filesystem::path> getDroppedAsset() const;
 
     bool isOpen() const { return m_open; }
     void close() { m_open = false; }
     void open()  { m_open = true; }
 
 private:
+    const char* iconForType(AssetType type);
+
     bool m_open = true;
     std::string m_rootPath = "assets";
     std::filesystem::path m_currentDir;

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -11,6 +11,7 @@
 #include "../src/editor/StatsOverlay.hpp"
 #include "../src/editor/HierarchyPanel.hpp"
 #include "../src/editor/SceneViewport.hpp"
+#include "../src/editor/AssetBrowser.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;
@@ -313,6 +314,24 @@ TEST_CASE("HierarchyPanel - close and open", "[editor][hierarchy]") {
     REQUIRE(panel.isOpen() == false);
     panel.open();
     REQUIRE(panel.isOpen() == true);
+}
+
+// ============================================================================
+// AssetBrowser Tests
+// ============================================================================
+
+TEST_CASE("AssetBrowser - Default state", "[editor][assetbrowser]") {
+    AssetBrowser browser;
+    REQUIRE(browser.isOpen() == true);
+}
+
+TEST_CASE("AssetBrowser - close and open", "[editor][assetbrowser]") {
+    AssetBrowser browser;
+    REQUIRE(browser.isOpen() == true);
+    browser.close();
+    REQUIRE(browser.isOpen() == false);
+    browser.open();
+    REQUIRE(browser.isOpen() == true);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Refactors `AssetBrowser` from a fully inline 181-line header to a clean `.hpp`/`.cpp` split following the same pattern established by `HierarchyPanel` (PR #84) and `SceneViewport` (PR #85).

### Changes

- **AssetBrowser.hpp** — Reduced from 181→51 lines. Clean class declaration with:
  - `Entry` struct (path, type, label)
  - `init()` / `refreshDirectory()` for filesystem scanning
  - `render()` for ImGui grid layout with directory navigation
  - `getDroppedAsset()` for drag-drop asset import
  - `isOpen()` / `close()` / `open()` visibility controls

- **AssetBrowser.cpp** (new) — 149-line implementation with:
  - Directory traversal via `std::filesystem::directory_iterator`
  - File type detection: `.caf`→Scene, `.png/.jpg/.tga`→Texture, `.wav/.ogg/.mp3`→Audio, `.obj`→Mesh
  - ImGui grid layout with column-based file/folder icons
  - Back button + breadcrumb directory navigation
  - Double-click to enter folders
  - Drag-drop source for assets (`ASSET_PATH` payload)
  - Selection highlight on hovered items
  - All code guarded by `#ifdef CF_HAS_IMGUI`

- **Bugfix**: `.caf` files incorrectly mapped to `AssetType::Texture` → now correctly mapped to `AssetType::Scene`
- **Addition**: `.tga` format added to supported texture file types (per spec RF6.5)

- **CMakeLists.txt** — Added `src/editor/AssetBrowser.cpp` to doppio executable
- **Tests** — Added AssetBrowser state tests (default state, close/open) matching existing patterns

### Backward Compatibility

Preserves the existing `SceneEditor` integration — `m_assetBrowser.init(assetsPath)` and `m_assetBrowser.render(m_ctx)` signatures unchanged.