### PR TITLE
refactor(editor): split InspectorPanel into .hpp/.cpp with component drawers (RF6.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
         src/editor/HierarchyPanel.cpp
         src/editor/SceneViewport.cpp
         src/editor/AssetBrowser.cpp
+        src/editor/InspectorPanel.cpp
     )
     target_link_libraries(doppio PRIVATE caffeine-core ImGui)
     target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/editor/InspectorPanel.cpp
+++ b/src/editor/InspectorPanel.cpp
@@ -1,0 +1,172 @@
+#include "editor/InspectorPanel.hpp"
+
+#ifdef CF_HAS_IMGUI
+
+namespace Caffeine::Editor {
+
+// ── Drawer registry ──────────────────────────────────────────────
+
+void InspectorPanel::registerDrawer(u32 componentTypeId, ComponentDrawer drawer) {
+    m_drawers.set(componentTypeId, std::move(drawer));
+}
+
+// ── Main render ──────────────────────────────────────────────────
+
+void InspectorPanel::render(ECS::World& world, EditorContext& ctx) {
+    if (!m_open) return;
+    if (ImGui::Begin("Inspector", &m_open)) {
+        if (!ctx.selectedEntity.isValid()) {
+            ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "No entity selected");
+            ImGui::End();
+            return;
+        }
+
+        ECS::Entity e = ctx.selectedEntity;
+
+        // Entity header
+        const char* name = getEntityName(world, e);
+        char nameBuf[64];
+        strncpy(nameBuf, name, sizeof(nameBuf));
+        nameBuf[sizeof(nameBuf) - 1] = '\0';
+        if (ImGui::InputText("##name", nameBuf, sizeof(nameBuf),
+                             ImGuiInputTextFlags_EnterReturnsTrue)) {
+            ctx.beginUndo(EditorCommand::SetField, e.id(), world);
+            setEntityName(world, e, nameBuf);
+            ctx.endUndo(world);
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("Entity %u", e.id());
+
+        ImGui::Separator();
+        ImGui::BeginChild("components");
+
+        drawTransform(world, e, ctx);
+        drawSprite(world, e, ctx);
+
+        ImGui::Separator();
+
+        // Add Component button
+        if (ImGui::Button("+ Add Component", ImVec2(-1, 0))) {
+            ImGui::OpenPopup("add_component");
+        }
+        if (ImGui::BeginPopup("add_component")) {
+            if (!world.has<ECS::Position2D>(e) && ImGui::MenuItem("Position2D")) {
+                ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                world.add<ECS::Position2D>(e);
+                ctx.endUndo(world);
+            }
+            if (!world.has<ECS::Velocity2D>(e) && ImGui::MenuItem("Velocity2D")) {
+                ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                world.add<ECS::Velocity2D>(e);
+                ctx.endUndo(world);
+            }
+            if (!world.has<ECS::Sprite>(e) && ImGui::MenuItem("Sprite")) {
+                ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                world.add<ECS::Sprite>(e);
+                ctx.endUndo(world);
+            }
+            if (!world.has<ECS::Health>(e) && ImGui::MenuItem("Health")) {
+                ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
+                world.add<ECS::Health>(e);
+                ctx.endUndo(world);
+            }
+            ImGui::EndPopup();
+        }
+
+        ImGui::EndChild();
+    }
+    ImGui::End();
+}
+
+// ── Transform drawer ─────────────────────────────────────────────
+
+void InspectorPanel::drawTransform(ECS::World& world, ECS::Entity e, EditorContext& ctx) {
+    if (!ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) return;
+
+    if (world.has<ECS::Position2D>(e)) {
+        auto* pos = world.get<ECS::Position2D>(e);
+        f32 p[2] = { pos->x, pos->y };
+        if (ImGui::DragFloat2("Position", p, 0.5f)) {
+            pos->x = p[0]; pos->y = p[1];
+            ctx.isDirty = true;
+        }
+    } else {
+        f32 p[2] = { 0, 0 };
+        if (ImGui::DragFloat2("Position", p, 0.5f)) {
+            world.add<ECS::Position2D>(e, p[0], p[1]);
+            ctx.isDirty = true;
+        }
+    }
+
+    if (world.has<ECS::Rotation>(e)) {
+        auto* rot = world.get<ECS::Rotation>(e);
+        f32 degrees = rot->angle * 180.0f / 3.14159265f;
+        if (ImGui::DragFloat("Rotation", &degrees, 1.0f, -360.0f, 360.0f)) {
+            rot->angle = degrees * 3.14159265f / 180.0f;
+            ctx.isDirty = true;
+        }
+    } else {
+        f32 degrees = 0;
+        if (ImGui::DragFloat("Rotation", &degrees, 1.0f, -360.0f, 360.0f)) {
+            ECS::Rotation r;
+            r.angle = degrees * 3.14159265f / 180.0f;
+            world.add<ECS::Rotation>(e, r);
+            ctx.isDirty = true;
+        }
+    }
+
+    if (world.has<ECS::Scale2D>(e)) {
+        auto* scl = world.get<ECS::Scale2D>(e);
+        f32 s[2] = { scl->x, scl->y };
+        if (ImGui::DragFloat2("Scale", s, 0.1f, 0.01f, 100.0f)) {
+            scl->x = s[0]; scl->y = s[1];
+            ctx.isDirty = true;
+        }
+    } else {
+        f32 s[2] = { 1, 1 };
+        if (ImGui::DragFloat2("Scale", s, 0.1f, 0.01f, 100.0f)) {
+            world.add<ECS::Scale2D>(e, s[0], s[1]);
+            ctx.isDirty = true;
+        }
+    }
+}
+
+// ── Sprite drawer ────────────────────────────────────────────────
+
+void InspectorPanel::drawSprite(ECS::World& world, ECS::Entity e, EditorContext& ctx) {
+    if (!world.has<ECS::Sprite>(e)) {
+        if (ImGui::CollapsingHeader("Sprite Renderer")) {
+            if (ImGui::Button("+ Add Sprite Renderer")) {
+                world.add<ECS::Sprite>(e);
+                ctx.isDirty = true;
+            }
+        }
+        return;
+    }
+
+    if (ImGui::CollapsingHeader("Sprite Renderer", ImGuiTreeNodeFlags_DefaultOpen)) {
+        auto* sprite = world.get<ECS::Sprite>(e);
+        char buf[256];
+        strncpy(buf, sprite->name.c_str(), sizeof(buf));
+        buf[sizeof(buf) - 1] = '\0';
+        if (ImGui::InputText("Texture", buf, sizeof(buf))) {
+            sprite->name = buf;
+            ctx.isDirty = true;
+        }
+        int frame = static_cast<int>(sprite->frameIndex);
+        if (ImGui::DragInt("Frame", &frame, 1, 0, 1000)) {
+            sprite->frameIndex = static_cast<u32>(frame > 0 ? frame : 0);
+            ctx.isDirty = true;
+        }
+    }
+}
+
+// ── Stub drawers ─────────────────────────────────────────────────
+
+void InspectorPanel::drawCamera(ECS::World&, ECS::Entity, EditorContext&) {}
+void InspectorPanel::drawRigidBody2D(ECS::World&, ECS::Entity, EditorContext&) {}
+void InspectorPanel::drawAudioSource(ECS::World&, ECS::Entity, EditorContext&) {}
+
+} // namespace Caffeine::Editor
+
+#endif // CF_HAS_IMGUI

--- a/src/editor/InspectorPanel.hpp
+++ b/src/editor/InspectorPanel.hpp
@@ -23,83 +23,8 @@ public:
 
     InspectorPanel() = default;
 
-    void registerDrawer(u32 componentTypeId, ComponentDrawer drawer) {
-#ifdef CF_HAS_IMGUI
-        m_drawers.set(id, std::move(drawer));
-#endif
-    }
-
-    void render(ECS::World& world, EditorContext& ctx) {
-#ifdef CF_HAS_IMGUI
-        if (!m_open) return;
-        if (ImGui::Begin("Inspector", &m_open)) {
-            if (!ctx.selectedEntity.isValid()) {
-                ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "No entity selected");
-                ImGui::End();
-                return;
-            }
-
-            ECS::Entity e = ctx.selectedEntity;
-
-            // Entity header
-            const char* name = getEntityName(world, e);
-            char nameBuf[64];
-            strncpy(nameBuf, name, sizeof(nameBuf));
-            nameBuf[sizeof(nameBuf) - 1] = '\0';
-            if (ImGui::InputText("##name", nameBuf, sizeof(nameBuf),
-                                 ImGuiInputTextFlags_EnterReturnsTrue)) {
-                ctx.beginUndo(EditorCommand::SetField, e.id(), world);
-                setEntityName(world, e, nameBuf);
-                ctx.endUndo(world);
-            }
-            ImGui::SameLine();
-            ImGui::TextDisabled("Entity %u", e.id());
-
-            ImGui::Separator();
-            ImGui::BeginChild("components");
-
-            // --- Transform ---
-            drawTransform(world, e, ctx);
-
-            // --- SpriteRenderer ---
-            drawSprite(world, e, ctx);
-
-            // --- Custom drawers ---
-
-            ImGui::Separator();
-            // Add Component button
-            if (ImGui::Button("+ Add Component", ImVec2(-1, 0))) {
-                ImGui::OpenPopup("add_component");
-            }
-            if (ImGui::BeginPopup("add_component")) {
-                if (!world.has<ECS::Position2D>(e) && ImGui::MenuItem("Position2D")) {
-                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
-                    world.add<ECS::Position2D>(e);
-                    ctx.endUndo(world);
-                }
-                if (!world.has<ECS::Velocity2D>(e) && ImGui::MenuItem("Velocity2D")) {
-                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
-                    world.add<ECS::Velocity2D>(e);
-                    ctx.endUndo(world);
-                }
-                if (!world.has<ECS::Sprite>(e) && ImGui::MenuItem("Sprite")) {
-                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
-                    world.add<ECS::Sprite>(e);
-                    ctx.endUndo(world);
-                }
-                if (!world.has<ECS::Health>(e) && ImGui::MenuItem("Health")) {
-                    ctx.beginUndo(EditorCommand::AddComponent, e.id(), world);
-                    world.add<ECS::Health>(e);
-                    ctx.endUndo(world);
-                }
-                ImGui::EndPopup();
-            }
-
-            ImGui::EndChild();
-        }
-        ImGui::End();
-#endif
-    }
+    void registerDrawer(u32 componentTypeId, ComponentDrawer drawer);
+    void render(ECS::World& world, EditorContext& ctx);
 
     bool isOpen() const { return m_open; }
     void close() { m_open = false; }
@@ -107,90 +32,11 @@ public:
 
 private:
 #ifdef CF_HAS_IMGUI
-    void drawTransform(ECS::World& world, ECS::Entity e, EditorContext& ctx) {
-        if (!ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) return;
-
-        // Position2D
-        if (world.has<ECS::Position2D>(e)) {
-            auto* pos = world.get<ECS::Position2D>(e);
-            f32 p[2] = { pos->x, pos->y };
-            if (ImGui::DragFloat2("Position", p, 0.5f)) {
-                pos->x = p[0]; pos->y = p[1];
-                ctx.isDirty = true;
-            }
-        } else {
-            f32 p[2] = { 0, 0 };
-            if (ImGui::DragFloat2("Position", p, 0.5f)) {
-                world.add<ECS::Position2D>(e, p[0], p[1]);
-                ctx.isDirty = true;
-            }
-        }
-
-        // Rotation
-        if (world.has<ECS::Rotation>(e)) {
-            auto* rot = world.get<ECS::Rotation>(e);
-            f32 degrees = rot->angle * 180.0f / 3.14159265f;
-            if (ImGui::DragFloat("Rotation", &degrees, 1.0f, -360.0f, 360.0f)) {
-                rot->angle = degrees * 3.14159265f / 180.0f;
-                ctx.isDirty = true;
-            }
-        } else {
-            f32 degrees = 0;
-            if (ImGui::DragFloat("Rotation", &degrees, 1.0f, -360.0f, 360.0f)) {
-                ECS::Rotation r; r.angle = degrees * 3.14159265f / 180.0f;
-                world.add<ECS::Rotation>(e, r);
-                ctx.isDirty = true;
-            }
-        }
-
-        // Scale2D
-        if (world.has<ECS::Scale2D>(e)) {
-            auto* scl = world.get<ECS::Scale2D>(e);
-            f32 s[2] = { scl->x, scl->y };
-            if (ImGui::DragFloat2("Scale", s, 0.1f, 0.01f, 100.0f)) {
-                scl->x = s[0]; scl->y = s[1];
-                ctx.isDirty = true;
-            }
-        } else {
-            f32 s[2] = { 1, 1 };
-            if (ImGui::DragFloat2("Scale", s, 0.1f, 0.01f, 100.0f)) {
-                world.add<ECS::Scale2D>(e, s[0], s[1]);
-                ctx.isDirty = true;
-            }
-        }
-    }
-
-    void drawSprite(ECS::World& world, ECS::Entity e, EditorContext& ctx) {
-        if (!world.has<ECS::Sprite>(e)) {
-            if (ImGui::CollapsingHeader("Sprite Renderer")) {
-                if (ImGui::Button("+ Add Sprite Renderer")) {
-                    world.add<ECS::Sprite>(e);
-                    ctx.isDirty = true;
-                }
-            }
-            return;
-        }
-
-        if (ImGui::CollapsingHeader("Sprite Renderer", ImGuiTreeNodeFlags_DefaultOpen)) {
-            auto* sprite = world.get<ECS::Sprite>(e);
-            char buf[256];
-            strncpy(buf, sprite->name.c_str(), sizeof(buf));
-            buf[sizeof(buf) - 1] = '\0';
-            if (ImGui::InputText("Texture", buf, sizeof(buf))) {
-                sprite->name = buf;
-                ctx.isDirty = true;
-            }
-            int frame = static_cast<int>(sprite->frameIndex);
-            if (ImGui::DragInt("Frame", &frame, 1, 0, 1000)) {
-                sprite->frameIndex = static_cast<u32>(frame > 0 ? frame : 0);
-                ctx.isDirty = true;
-            }
-        }
-    }
-
-    void drawCamera(ECS::World&, ECS::Entity, EditorContext&) {}
-    void drawRigidBody2D(ECS::World&, ECS::Entity, EditorContext&) {}
-    void drawAudioSource(ECS::World&, ECS::Entity, EditorContext&) {}
+    void drawTransform(ECS::World& world, ECS::Entity e, EditorContext& ctx);
+    void drawSprite(ECS::World& world, ECS::Entity e, EditorContext& ctx);
+    void drawCamera(ECS::World& world, ECS::Entity e, EditorContext& ctx);
+    void drawRigidBody2D(ECS::World& world, ECS::Entity e, EditorContext& ctx);
+    void drawAudioSource(ECS::World& world, ECS::Entity e, EditorContext& ctx);
 #endif
 
     bool m_open = true;

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -12,6 +12,7 @@
 #include "../src/editor/HierarchyPanel.hpp"
 #include "../src/editor/SceneViewport.hpp"
 #include "../src/editor/AssetBrowser.hpp"
+#include "../src/editor/InspectorPanel.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;
@@ -332,6 +333,24 @@ TEST_CASE("AssetBrowser - close and open", "[editor][assetbrowser]") {
     REQUIRE(browser.isOpen() == false);
     browser.open();
     REQUIRE(browser.isOpen() == true);
+}
+
+// ============================================================================
+// InspectorPanel Tests
+// ============================================================================
+
+TEST_CASE("InspectorPanel - Default state", "[editor][inspector]") {
+    InspectorPanel panel;
+    REQUIRE(panel.isOpen() == true);
+}
+
+TEST_CASE("InspectorPanel - close and open", "[editor][inspector]") {
+    InspectorPanel panel;
+    REQUIRE(panel.isOpen() == true);
+    panel.close();
+    REQUIRE(panel.isOpen() == false);
+    panel.open();
+    REQUIRE(panel.isOpen() == true);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Refactors `InspectorPanel` from a fully inline 200-line header to a clean `.hpp`/`.cpp` split following the same pattern established by `HierarchyPanel`, `SceneViewport`, and `AssetBrowser`.

### Changes

- **InspectorPanel.hpp** — Reduced from 200→46 lines. Clean class declaration with:
  - `ComponentDrawer` type alias for extensible drawer registry
  - `registerDrawer()` for custom component UI injection
  - `render()` for entity property editing
  - `isOpen()` / `close()` / `open()` visibility controls

- **InspectorPanel.cpp** (new) — 171-line implementation with:
  - Entity name editing with undo support
  - Transform drawer: Position2D (DragFloat2), Rotation (DragFloat, deg↔rad), Scale2D (DragFloat2)
  - Sprite Renderer drawer: texture name input, frame index drag
  - "Add Component" popup menu (Position2D, Velocity2D, Sprite, Health)
  - All edits set `ctx.isDirty = true`
  - Stub drawers for Camera, RigidBody2D, AudioSource (extensible)
  - All code guarded by `#ifdef CF_HAS_IMGUI`

- **Bugfix**: `registerDrawer` had a parameter mismatch (`id` vs `componentTypeId`) — fixed

- **CMakeLists.txt** — Added `src/editor/InspectorPanel.cpp` to doppio executable
- **Tests** — Added InspectorPanel state tests (default state, close/open)

### Backward Compatibility

Preserves the existing `SceneEditor` integration — `m_inspector.render(world, m_ctx)` signature unchanged.