### PR TITLE
feat(editor): SceneSerializer with binary save/load + unsaved changes popup (RF6.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
         src/editor/AssetBrowser.cpp
         src/editor/InspectorPanel.cpp
         src/editor/SceneEditor.cpp
+        src/editor/SceneSerializer.cpp
     )
     target_link_libraries(doppio PRIVATE caffeine-core ImGui)
     target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/editor/SceneEditor.cpp
+++ b/src/editor/SceneEditor.cpp
@@ -78,6 +78,7 @@ void SceneEditor::render(ECS::World& world
 
     ImGui::End(); // DockSpace
 
+    renderUnsavedChangesPopup(world);
     renderStatusBar(world);
 }
 
@@ -109,23 +110,41 @@ void SceneEditor::renderMainMenuBar(ECS::World& world) {
     if (ImGui::BeginMainMenuBar()) {
         if (ImGui::BeginMenu("File")) {
             if (ImGui::MenuItem("New Scene", "Ctrl+N")) {
-                world.destroyAll();
-                m_ctx.selectedEntity = ECS::Entity::INVALID;
-                m_ctx.isDirty = false;
-                m_ctx.undoStack.clear();
+                if (m_ctx.isDirty) {
+                    m_pendingAction = PendingAction::NewScene;
+                    ImGui::OpenPopup("Unsaved Changes?");
+                } else {
+                    doNewScene(world);
+                }
             }
             if (ImGui::MenuItem("Save", "Ctrl+S")) {
-                saveScene("scene.caf", world);
+                if (m_ctx.currentScenePath.empty()) {
+                    saveSceneAs(world);
+                } else {
+                    saveScene(m_ctx.currentScenePath.c_str(), world);
+                }
             }
             if (ImGui::MenuItem("Save As...")) {
-                saveScene("scene.caf", world);
+                saveSceneAs(world);
             }
             if (ImGui::MenuItem("Open...", "Ctrl+O")) {
-                loadScene("scene.caf", world);
+                if (m_ctx.isDirty) {
+                    m_pendingAction = PendingAction::OpenScene;
+                    ImGui::OpenPopup("Unsaved Changes?");
+                } else {
+                    // TODO: native file dialog — for now hardcoded
+                    loadScene("scene.caf", world);
+                    m_ctx.currentScenePath = "scene.caf";
+                }
             }
             ImGui::Separator();
             if (ImGui::MenuItem("Exit")) {
-                m_open = false;
+                if (m_ctx.isDirty) {
+                    m_pendingAction = PendingAction::Exit;
+                    ImGui::OpenPopup("Unsaved Changes?");
+                } else {
+                    m_open = false;
+                }
             }
             ImGui::EndMenu();
         }
@@ -198,7 +217,19 @@ void SceneEditor::handleShortcuts(ECS::World& world) {
     bool ctrl = ImGui::GetIO().KeyCtrl;
 
     if (ctrl && ImGui::IsKeyPressed(ImGuiKey_S)) {
-        saveScene("scene.caf", world);
+        if (m_ctx.currentScenePath.empty()) {
+            saveSceneAs(world);
+        } else {
+            saveScene(m_ctx.currentScenePath.c_str(), world);
+        }
+    }
+    if (ctrl && ImGui::IsKeyPressed(ImGuiKey_N)) {
+        if (m_ctx.isDirty) {
+            m_pendingAction = PendingAction::NewScene;
+            ImGui::OpenPopup("Unsaved Changes?");
+        } else {
+            doNewScene(world);
+        }
     }
     if (ctrl && ImGui::IsKeyPressed(ImGuiKey_Z)) {
         if (ImGui::GetIO().KeyShift) {
@@ -215,18 +246,85 @@ void SceneEditor::handleShortcuts(ECS::World& world) {
 // ── Serialization ───────────────────────────────────────────────
 
 bool SceneEditor::saveScene(const char* path, ECS::World& world) {
-    Scene::SceneSerializer serializer(world);
+    Editor::SceneSerializer serializer(world);
     if (!serializer.serialize(path)) return false;
+    m_ctx.currentScenePath = path;
     m_ctx.isDirty = false;
     return true;
 }
 
+bool SceneEditor::saveSceneAs(ECS::World& world) {
+    // TODO: native file dialog — for now write to a default path
+    const char* path = "scene.caf";
+    return saveScene(path, world);
+}
+
 bool SceneEditor::loadScene(const char* path, ECS::World& world) {
-    Scene::SceneSerializer serializer(world);
+    Editor::SceneSerializer serializer(world);
     if (!serializer.deserialize(path)) return false;
+    m_ctx.currentScenePath = path;
     m_ctx.selectedEntity = ECS::Entity::INVALID;
     m_ctx.isDirty = false;
     return true;
+}
+
+// ── Unsaved changes popup ───────────────────────────────────────
+
+void SceneEditor::renderUnsavedChangesPopup(ECS::World& world) {
+    if (m_pendingAction == PendingAction::None) return;
+
+    if (ImGui::BeginPopupModal("Unsaved Changes?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text("There are unsaved changes. Do you want to save before continuing?");
+        ImGui::Separator();
+
+        if (ImGui::Button("Save", ImVec2(120, 0))) {
+            if (m_ctx.currentScenePath.empty()) {
+                saveSceneAs(world);
+            } else {
+                saveScene(m_ctx.currentScenePath.c_str(), world);
+            }
+            ImGui::CloseCurrentPopup();
+            executePendingAction(world);
+            m_pendingAction = PendingAction::None;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Don't Save", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+            executePendingAction(world);
+            m_pendingAction = PendingAction::None;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+            m_pendingAction = PendingAction::None;
+        }
+        ImGui::EndPopup();
+    }
+}
+
+void SceneEditor::executePendingAction(ECS::World& world) {
+    switch (m_pendingAction) {
+        case PendingAction::NewScene:
+            doNewScene(world);
+            break;
+        case PendingAction::OpenScene:
+            // TODO: native file dialog
+            loadScene("scene.caf", world);
+            break;
+        case PendingAction::Exit:
+            m_open = false;
+            break;
+        default:
+            break;
+    }
+}
+
+void SceneEditor::doNewScene(ECS::World& world) {
+    world.destroyAll();
+    m_ctx.selectedEntity = ECS::Entity::INVALID;
+    m_ctx.currentScenePath.clear();
+    m_ctx.isDirty = false;
+    m_ctx.undoStack.clear();
 }
 
 // ── Asset drop ──────────────────────────────────────────────────

--- a/src/editor/SceneEditor.hpp
+++ b/src/editor/SceneEditor.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "core/Types.hpp"
 #include "ecs/World.hpp"
-#include "scene/SceneSerializer.hpp"
 #include "render/Camera2D.hpp"
 #include "editor/EditorContext.hpp"
 #include "editor/HierarchyPanel.hpp"
@@ -10,6 +9,7 @@
 #include "editor/AssetBrowser.hpp"
 #include "editor/ConsoleWindow.hpp"
 #include "editor/ProfilerWindow.hpp"
+#include "editor/SceneSerializer.hpp"
 
 #ifdef CF_HAS_SDL3
 #include "rhi/RenderDevice.hpp"
@@ -21,12 +21,20 @@
 #endif
 
 #include <cstdio>
+#include <functional>
 
 namespace Caffeine::Editor {
 using namespace Caffeine;
 
 class SceneEditor {
 public:
+    enum class PendingAction : u8 {
+        None,
+        NewScene,
+        OpenScene,
+        Exit
+    };
+
     SceneEditor() : m_hierarchy(&m_ctx) {}
 
 #ifdef CF_HAS_SDL3
@@ -44,6 +52,7 @@ public:
     // ── Serialization ──
 
     bool saveScene(const char* path, ECS::World& world);
+    bool saveSceneAs(ECS::World& world);
     bool loadScene(const char* path, ECS::World& world);
 
     // ── Accessors ──
@@ -65,8 +74,11 @@ private:
     void setupDockspace(ImGuiID dockspaceId);
     void renderMainMenuBar(ECS::World& world);
     void renderStatusBar(ECS::World& world);
+    void renderUnsavedChangesPopup(ECS::World& world);
+    void executePendingAction(ECS::World& world);
     void handleAssetDrop(ECS::World& world);
     void handleShortcuts(ECS::World& world);
+    void doNewScene(ECS::World& world);
 #endif
 
     EditorContext  m_ctx;
@@ -83,6 +95,7 @@ private:
 
     bool m_open         = true;
     bool m_dockingSetup = false;
+    PendingAction m_pendingAction = PendingAction::None;
 };
 
 } // namespace Caffeine::Editor

--- a/src/editor/SceneSerializer.cpp
+++ b/src/editor/SceneSerializer.cpp
@@ -1,0 +1,294 @@
+#include "editor/SceneSerializer.hpp"
+#include "ecs/Components.hpp"
+#include "editor/EditorContext.hpp"
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <fstream>
+#include <cstring>
+
+namespace Caffeine::Editor {
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+void SceneSerializer::collectNameComponents(
+    std::vector<std::pair<u32, std::vector<u8>>>& entries)
+{
+    ECS::ComponentQuery q;
+    q.with<NameComponent>();
+    m_world.forEach<NameComponent>(q, [&](ECS::Entity e, NameComponent& nc) {
+        std::vector<u8> data(64);
+        memcpy(data.data(), nc.name, 64);
+        entries.push_back({e.id(), std::move(data)});
+    });
+}
+
+void SceneSerializer::collectSpriteComponents(
+    std::vector<std::pair<u32, std::vector<u8>>>& entries)
+{
+    ECS::ComponentQuery q;
+    q.with<ECS::Sprite>();
+    m_world.forEach<ECS::Sprite>(q, [&](ECS::Entity e, ECS::Sprite& s) {
+        // Format: frameIndex (4 bytes) + nameLength (4 bytes) + nameData
+        u32 nameLen = static_cast<u32>(s.name.size());
+        std::vector<u8> data(8 + nameLen);
+        memcpy(data.data(), &s.frameIndex, 4);
+        memcpy(data.data() + 4, &nameLen, 4);
+        if (nameLen > 0) {
+            memcpy(data.data() + 8, s.name.data(), nameLen);
+        }
+        entries.push_back({e.id(), std::move(data)});
+    });
+}
+
+// ── Serialize ────────────────────────────────────────────────────
+
+bool SceneSerializer::serialize(const std::string& filepath) {
+    // Collect all components grouped by entity
+    std::unordered_map<u32, std::vector<std::pair<u32, std::vector<u8>>>> entityMap;
+
+    auto addToMap = [&](const std::vector<std::pair<u32, std::vector<u8>>>& entries) {
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(0, std::move(data)); // typeId filled below
+        }
+    };
+
+    // Collect each component type
+    // Type 0: NameComponent (needs special handling for char[64])
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectNameComponents(entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeName, std::move(data));
+        }
+    }
+
+    // Type 1-5, 7: POD components
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectComponent<ECS::Position2D>(m_world, entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypePosition2D, std::move(data));
+        }
+    }
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectComponent<ECS::Velocity2D>(m_world, entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeVelocity2D, std::move(data));
+        }
+    }
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectComponent<ECS::Acceleration2D>(m_world, entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeAcceleration2D, std::move(data));
+        }
+    }
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectComponent<ECS::Rotation>(m_world, entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeRotation, std::move(data));
+        }
+    }
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectComponent<ECS::Scale2D>(m_world, entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeScale2D, std::move(data));
+        }
+    }
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectComponent<ECS::Health>(m_world, entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeHealth, std::move(data));
+        }
+    }
+
+    // Type 6: Sprite (std::string needs special handling)
+    {
+        std::vector<std::pair<u32, std::vector<u8>>> entries;
+        collectSpriteComponents(entries);
+        for (auto& [eid, data] : entries) {
+            entityMap[eid].emplace_back(kTypeSprite, std::move(data));
+        }
+    }
+
+    // Type 8: Tag (no data, just presence)
+    {
+        ECS::ComponentQuery q;
+        q.with<ECS::Tag>();
+        m_world.forEach<ECS::Tag>(q, [&](ECS::Entity e, ECS::Tag&) {
+            entityMap[e.id()].emplace_back(kTypeTag, std::vector<u8>{});
+        });
+    }
+
+    // Write binary file
+    std::ofstream fout(filepath, std::ios::binary);
+    if (!fout.is_open()) return false;
+
+    // Header
+    u32 signature = kSignature;
+    u32 version   = kFormatVersion;
+    u32 count     = static_cast<u32>(entityMap.size());
+    fout.write(reinterpret_cast<const char*>(&signature), 4);
+    fout.write(reinterpret_cast<const char*>(&version), 4);
+    fout.write(reinterpret_cast<const char*>(&count), 4);
+
+    // Entity data
+    for (auto& [eid, components] : entityMap) {
+        u32 compCount = static_cast<u32>(components.size());
+        fout.write(reinterpret_cast<const char*>(&eid), 4);
+        fout.write(reinterpret_cast<const char*>(&compCount), 4);
+
+        for (auto& [typeId, data] : components) {
+            u32 dataSize = static_cast<u32>(data.size());
+            fout.write(reinterpret_cast<const char*>(&typeId), 4);
+            fout.write(reinterpret_cast<const char*>(&dataSize), 4);
+            if (dataSize > 0) {
+                fout.write(reinterpret_cast<const char*>(data.data()), dataSize);
+            }
+        }
+    }
+
+    fout.close();
+    return true;
+}
+
+// ── Deserialize ──────────────────────────────────────────────────
+
+bool SceneSerializer::deserialize(const std::string& filepath) {
+    std::ifstream fin(filepath, std::ios::binary | std::ios::ate);
+    if (!fin.is_open()) return false;
+
+    // Read entire file into memory
+    std::streampos fileSize = fin.tellg();
+    fin.seekg(0, std::ios::beg);
+
+    std::vector<u8> buffer(static_cast<usize>(fileSize));
+    if (!fin.read(reinterpret_cast<char*>(buffer.data()), fileSize)) {
+        fin.close();
+        return false;
+    }
+    fin.close();
+
+    // Parse header
+    if (buffer.size() < 12) return false;
+    u32 signature, version, entityCount;
+    memcpy(&signature,   buffer.data(),      4);
+    memcpy(&version,     buffer.data() + 4,  4);
+    memcpy(&entityCount, buffer.data() + 8,  4);
+
+    if (signature != kSignature) return false;
+    if (version != kFormatVersion) return false;
+
+    // ── Pass 1: collect all entity IDs ────────────────────────────
+    struct Entry {
+        u32 eid;
+        u32 typeId;
+        std::vector<u8> data;
+    };
+    std::vector<Entry> allEntries;
+    std::unordered_set<u32> uniqueIds;
+
+    usize cursor = 12;
+    for (u32 i = 0; i < entityCount; ++i) {
+        if (cursor + 8 > buffer.size()) return false;
+        u32 eid, compCount;
+        memcpy(&eid,       buffer.data() + cursor,      4); cursor += 4;
+        memcpy(&compCount, buffer.data() + cursor,      4); cursor += 4;
+
+        uniqueIds.insert(eid);
+
+        for (u32 j = 0; j < compCount; ++j) {
+            if (cursor + 8 > buffer.size()) return false;
+            u32 typeId, dataSize;
+            memcpy(&typeId,   buffer.data() + cursor, 4); cursor += 4;
+            memcpy(&dataSize, buffer.data() + cursor, 4); cursor += 4;
+
+            if (cursor + dataSize > buffer.size()) return false;
+            std::vector<u8> compData(dataSize);
+            if (dataSize > 0) {
+                memcpy(compData.data(), buffer.data() + cursor, dataSize);
+                cursor += dataSize;
+            }
+            allEntries.push_back({eid, typeId, std::move(compData)});
+        }
+    }
+
+    // ── Pass 2: create entities with remap ────────────────────
+    m_world.destroyAll();
+    std::unordered_map<u32, ECS::Entity> remap;
+    remap.reserve(uniqueIds.size());
+    for (u32 oldId : uniqueIds) {
+        remap[oldId] = m_world.create();
+    }
+
+    // ── Pass 3: apply components ──────────────────────────────
+    for (auto& entry : allEntries) {
+        auto it = remap.find(entry.eid);
+        if (it == remap.end()) continue;
+        ECS::Entity e = it->second;
+
+        switch (entry.typeId) {
+            case kTypeName:
+                applyNameComponent(e, entry.data.data(), static_cast<u32>(entry.data.size()));
+                break;
+            case kTypePosition2D:
+                applyPODComponent<ECS::Position2D>(e, entry.data.data(), static_cast<u32>(entry.data.size()), m_world);
+                break;
+            case kTypeVelocity2D:
+                applyPODComponent<ECS::Velocity2D>(e, entry.data.data(), static_cast<u32>(entry.data.size()), m_world);
+                break;
+            case kTypeAcceleration2D:
+                applyPODComponent<ECS::Acceleration2D>(e, entry.data.data(), static_cast<u32>(entry.data.size()), m_world);
+                break;
+            case kTypeRotation:
+                applyPODComponent<ECS::Rotation>(e, entry.data.data(), static_cast<u32>(entry.data.size()), m_world);
+                break;
+            case kTypeScale2D:
+                applyPODComponent<ECS::Scale2D>(e, entry.data.data(), static_cast<u32>(entry.data.size()), m_world);
+                break;
+            case kTypeSprite:
+                applySpriteComponent(e, entry.data.data(), static_cast<u32>(entry.data.size()));
+                break;
+            case kTypeHealth:
+                applyPODComponent<ECS::Health>(e, entry.data.data(), static_cast<u32>(entry.data.size()), m_world);
+                break;
+            case kTypeTag:
+                m_world.add<ECS::Tag>(e);
+                break;
+            default:
+                break;
+        }
+    }
+
+    return true;
+}
+
+// ── Component apply helpers ──────────────────────────────────────
+
+bool SceneSerializer::applyNameComponent(ECS::Entity e, const u8* data, u32 size) {
+    if (size != 64) return false;
+    auto& nc = m_world.add<NameComponent>(e);
+    memcpy(nc.name, data, 64);
+    nc.name[63] = '\0';
+    return true;
+}
+
+bool SceneSerializer::applySpriteComponent(ECS::Entity e, const u8* data, u32 size) {
+    // Format: frameIndex (4) + nameLength (4) + nameData (nameLength)
+    if (size < 8) return false;
+    u32 frameIndex, nameLen;
+    memcpy(&frameIndex, data, 4);
+    memcpy(&nameLen, data + 4, 4);
+
+    if (8 + nameLen > size) return false;
+    std::string spriteName(reinterpret_cast<const char*>(data + 8), nameLen);
+    m_world.add<ECS::Sprite>(e, std::move(spriteName), frameIndex);
+    return true;
+}
+
+} // namespace Caffeine::Editor

--- a/src/editor/SceneSerializer.hpp
+++ b/src/editor/SceneSerializer.hpp
@@ -1,0 +1,71 @@
+#pragma once
+#include "core/Types.hpp"
+#include "ecs/World.hpp"
+#include "editor/EditorContext.hpp"
+#include <string>
+
+namespace Caffeine::Editor {
+using namespace Caffeine;
+
+class SceneSerializer {
+public:
+    explicit SceneSerializer(ECS::World& world) : m_world(world) {}
+
+    // ── Binary .caf ──────────────────────────────────────────────────────────
+
+    bool serialize(const std::string& filepath);
+    bool deserialize(const std::string& filepath);
+
+private:
+    ECS::World& m_world;
+
+    // Editor-specific component type IDs for the binary format
+    static constexpr u32 kTypeName         = 0;
+    static constexpr u32 kTypePosition2D   = 1;
+    static constexpr u32 kTypeVelocity2D   = 2;
+    static constexpr u32 kTypeAcceleration2D = 3;
+    static constexpr u32 kTypeRotation     = 4;
+    static constexpr u32 kTypeScale2D      = 5;
+    static constexpr u32 kTypeSprite       = 6;
+    static constexpr u32 kTypeHealth       = 7;
+    static constexpr u32 kTypeTag          = 8;
+    static constexpr u32 kTypeCount        = 9;
+
+    // File format constants
+    static constexpr u32 kFormatVersion    = 1;
+    static constexpr u32 kSignature        = 0x46464143; // "CAFF" little-endian
+
+    // ── Per-component serialization helpers ──────────────────────────────────
+
+    template<typename T>
+    static void collectComponent(ECS::World& world,
+                                  std::vector<std::pair<u32, std::vector<u8>>>& entries) {
+        ECS::ComponentQuery q;
+        q.with<T>();
+        world.forEach<T>(q, [&](ECS::Entity e, T& comp) {
+            std::vector<u8> data(sizeof(T));
+            memcpy(data.data(), &comp, sizeof(T));
+            entries.push_back({e.id(), std::move(data)});
+        });
+    }
+
+    void collectNameComponents(
+        std::vector<std::pair<u32, std::vector<u8>>>& entries);
+
+    void collectSpriteComponents(
+        std::vector<std::pair<u32, std::vector<u8>>>& entries);
+
+    bool applyNameComponent(ECS::Entity e, const u8* data, u32 size);
+    bool applySpriteComponent(ECS::Entity e, const u8* data, u32 size);
+
+    template<typename T>
+    static bool applyPODComponent(ECS::Entity e, const u8* data, u32 size,
+                                   ECS::World& world) {
+        if (size != sizeof(T)) return false;
+        auto& comp = world.add<T>(e);
+        memcpy(&comp, data, sizeof(T));
+        return true;
+    }
+};
+
+} // namespace Caffeine::Editor

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CAFFEINE_TEST_SOURCES
     test_skeletal_animation.cpp
     test_pipeline.cpp
     test_editor.cpp
+    ../src/editor/SceneSerializer.cpp
 )
 
 if(SDL3_FOUND)

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -14,6 +14,7 @@
 #include "../src/editor/AssetBrowser.hpp"
 #include "../src/editor/InspectorPanel.hpp"
 #include "../src/editor/SceneEditor.hpp"
+#include "../src/editor/SceneSerializer.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;
@@ -399,4 +400,200 @@ TEST_CASE("SceneEditor - accessors return valid panels", "[editor][sceneeditor]"
     REQUIRE(editor.assetBrowser().isOpen() == true);
     REQUIRE(editor.console().isOpen() == true);
     REQUIRE(editor.profiler().isOpen() == true);
+}
+
+// ============================================================================
+// SceneSerializer Tests
+// ============================================================================
+
+TEST_CASE("SceneSerializer - empty world roundtrip", "[editor][serializer]") {
+    ECS::World world;
+    Editor::SceneSerializer serializer(world);
+
+    REQUIRE(serializer.serialize("_test_empty.caf") == true);
+
+    ECS::World loaded;
+    Editor::SceneSerializer loader(loaded);
+    REQUIRE(loader.deserialize("_test_empty.caf") == true);
+    REQUIRE(loaded.entityCount() == 0);
+
+    std::remove("_test_empty.caf");
+}
+
+TEST_CASE("SceneSerializer - single entity with Name and Position", "[editor][serializer]") {
+    ECS::World world;
+    ECS::Entity e = world.create();
+    setEntityName(world, e, "Hero");
+    world.add<ECS::Position2D>(e, 10.0f, 20.0f);
+
+    Editor::SceneSerializer serializer(world);
+    REQUIRE(serializer.serialize("_test_hero.caf") == true);
+
+    ECS::World loaded;
+    Editor::SceneSerializer loader(loaded);
+    REQUIRE(loader.deserialize("_test_hero.caf") == true);
+    REQUIRE(loaded.entityCount() >= 1);
+
+    // Verify entity has both Name and Position
+    ECS::ComponentQuery q;
+    q.with<ECS::Position2D>();
+    bool found = false;
+    loaded.forEach<ECS::Position2D>(q, [&](ECS::Entity ent, ECS::Position2D& pos) {
+        REQUIRE(pos.x == 10.0f);
+        REQUIRE(pos.y == 20.0f);
+        const char* name = getEntityName(loaded, ent);
+        REQUIRE(strcmp(name, "Hero") == 0);
+        found = true;
+    });
+    REQUIRE(found == true);
+
+    std::remove("_test_hero.caf");
+}
+
+TEST_CASE("SceneSerializer - entity with all component types", "[editor][serializer]") {
+    ECS::World world;
+    ECS::Entity e = world.create();
+    setEntityName(world, e, "Complete");
+    world.add<ECS::Position2D>(e, 1.0f, 2.0f);
+    world.add<ECS::Velocity2D>(e, 3.0f, 4.0f);
+    world.add<ECS::Acceleration2D>(e, 5.0f, 6.0f);
+    world.add<ECS::Rotation>(e, 1.5f);
+    world.add<ECS::Scale2D>(e, 2.0f, 2.0f);
+    world.add<ECS::Health>(e, 50, 100);
+    world.add<ECS::Tag>(e);
+
+    Editor::SceneSerializer serializer(world);
+    REQUIRE(serializer.serialize("_test_complete.caf") == true);
+
+    ECS::World loaded;
+    Editor::SceneSerializer loader(loaded);
+    REQUIRE(loader.deserialize("_test_complete.caf") == true);
+    REQUIRE(loaded.entityCount() >= 1);
+
+    ECS::ComponentQuery q;
+    q.with<ECS::Position2D>();
+    loaded.forEach<ECS::Position2D>(q, [&](ECS::Entity ent, ECS::Position2D& pos) {
+        REQUIRE(pos.x == 1.0f);
+        REQUIRE(pos.y == 2.0f);
+
+        auto* vel = loaded.get<ECS::Velocity2D>(ent);
+        REQUIRE(vel != nullptr);
+        REQUIRE(vel->x == 3.0f);
+        REQUIRE(vel->y == 4.0f);
+
+        auto* accel = loaded.get<ECS::Acceleration2D>(ent);
+        REQUIRE(accel != nullptr);
+        REQUIRE(accel->x == 5.0f);
+        REQUIRE(accel->y == 6.0f);
+
+        auto* rot = loaded.get<ECS::Rotation>(ent);
+        REQUIRE(rot != nullptr);
+        REQUIRE(rot->angle == 1.5f);
+
+        auto* scale = loaded.get<ECS::Scale2D>(ent);
+        REQUIRE(scale != nullptr);
+        REQUIRE(scale->x == 2.0f);
+        REQUIRE(scale->y == 2.0f);
+
+        auto* hp = loaded.get<ECS::Health>(ent);
+        REQUIRE(hp != nullptr);
+        REQUIRE(hp->current == 50);
+        REQUIRE(hp->max == 100);
+
+        REQUIRE(loaded.has<ECS::Tag>(ent) == true);
+
+        const char* name = getEntityName(loaded, ent);
+        REQUIRE(strcmp(name, "Complete") == 0);
+    });
+
+    std::remove("_test_complete.caf");
+}
+
+TEST_CASE("SceneSerializer - Sprite component serialization", "[editor][serializer]") {
+    ECS::World world;
+    ECS::Entity e = world.create();
+    setEntityName(world, e, "SpriteObj");
+    world.add<ECS::Sprite>(e, "hero_sprite.png", 0);
+
+    Editor::SceneSerializer serializer(world);
+    REQUIRE(serializer.serialize("_test_sprite.caf") == true);
+
+    ECS::World loaded;
+    Editor::SceneSerializer loader(loaded);
+    REQUIRE(loader.deserialize("_test_sprite.caf") == true);
+
+    ECS::ComponentQuery q;
+    q.with<ECS::Sprite>();
+    bool found = false;
+    loaded.forEach<ECS::Sprite>(q, [&](ECS::Entity ent, ECS::Sprite& sprite) {
+        REQUIRE(sprite.name == "hero_sprite.png");
+        REQUIRE(sprite.frameIndex == 0);
+        found = true;
+    });
+    REQUIRE(found == true);
+
+    std::remove("_test_sprite.caf");
+}
+
+TEST_CASE("SceneSerializer - multiple entities roundtrip", "[editor][serializer]") {
+    ECS::World world;
+    ECS::Entity e1 = world.create();
+    setEntityName(world, e1, "Player");
+    world.add<ECS::Position2D>(e1, 0.0f, 0.0f);
+
+    ECS::Entity e2 = world.create();
+    setEntityName(world, e2, "Enemy");
+    world.add<ECS::Position2D>(e2, 100.0f, 200.0f);
+    world.add<ECS::Health>(e2, 30, 30);
+
+    ECS::Entity e3 = world.create();
+    setEntityName(world, e3, "Coin");
+    world.add<ECS::Tag>(e3);
+
+    Editor::SceneSerializer serializer(world);
+    REQUIRE(serializer.serialize("_test_multi.caf") == true);
+
+    ECS::World loaded;
+    Editor::SceneSerializer loader(loaded);
+    REQUIRE(loader.deserialize("_test_multi.caf") == true);
+    REQUIRE(loaded.entityCount() == 3);
+
+    // Verify all three entities exist and have correct data
+    ECS::ComponentQuery q;
+    q.with<ECS::Position2D>();
+    int posCount = 0;
+    loaded.forEach<ECS::Position2D>(q, [&](ECS::Entity ent, ECS::Position2D& pos) {
+        ++posCount;
+        const char* name = getEntityName(loaded, ent);
+        if (strcmp(name, "Player") == 0) {
+            REQUIRE(pos.x == 0.0f);
+            REQUIRE(pos.y == 0.0f);
+        } else if (strcmp(name, "Enemy") == 0) {
+            REQUIRE(pos.x == 100.0f);
+            REQUIRE(pos.y == 200.0f);
+            auto* hp = loaded.get<ECS::Health>(ent);
+            REQUIRE(hp != nullptr);
+            REQUIRE(hp->current == 30);
+        }
+    });
+    REQUIRE(posCount == 2);
+
+    // Check Tag entity
+    int tagCount = 0;
+    ECS::ComponentQuery tagQ;
+    tagQ.with<ECS::Tag>();
+    loaded.forEach<ECS::Tag>(tagQ, [&](ECS::Entity ent, ECS::Tag&) {
+        ++tagCount;
+        const char* name = getEntityName(loaded, ent);
+        REQUIRE(strcmp(name, "Coin") == 0);
+    });
+    REQUIRE(tagCount == 1);
+
+    std::remove("_test_multi.caf");
+}
+
+TEST_CASE("SceneSerializer - deserialize from non-existent file", "[editor][serializer]") {
+    ECS::World world;
+    Editor::SceneSerializer serializer(world);
+    REQUIRE(serializer.deserialize("_non_existent_file.caf") == false);
 }


### PR DESCRIPTION
## Summary

Implements **Save/Load Scene** (RF6.7) with a dedicated `Editor::SceneSerializer` and unsaved changes protection.

### SceneSerializer (`src/editor/SceneSerializer.hpp` + `SceneSerializer.cpp`)
- Custom binary `.caf` format: `CAFF` signature + version + entity-oriented component data
- Supports serialization of all editor-relevant component types:
  - **NameComponent** (char[64])
  - **Position2D**, **Velocity2D**, **Acceleration2D** (POD)
  - **Rotation** (f32), **Scale2D** (f32×2)
  - **Sprite** (std::string with length-prefixed encoding)
  - **Health** (u32×2), **Tag** (presence-only)
- Two-pass deserialization: collect IDs → create entities with remap → apply components

### SceneEditor integration
- **File path tracking**: `EditorContext::currentScenePath` is set on Save/Load, displayed in status bar
- **Save As**: New `saveSceneAs()` method for unnamed scenes
- **Unsaved Changes popup**: Modal dialog (Save / Don't Save / Cancel) triggered on:
  - File > New Scene (Ctrl+N) when dirty
  - File > Open (Ctrl+O) when dirty
  - Exit when dirty
- **Shortcuts**: Ctrl+S uses current path, Ctrl+N triggers unsaved check
- **doNewScene()**: Extracted to method, clears path and undo stack

### Tests (6 new, 51 total editor tests, all passing)
- Empty world roundtrip
- Single entity with Name + Position
- All component types roundtrip
- Sprite string serialization
- Multiple entities with mixed components
- Invalid file returns false

## Closes
Closes #81