### PR TITLE
feat(editor): DragDropSystem with AssetBrowser→Viewport and Inspector asset drops (RF6.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ if(SDL3_FOUND AND NOT CAFFEINE_BUILD_HEADLESS)
         src/editor/InspectorPanel.cpp
         src/editor/SceneEditor.cpp
         src/editor/SceneSerializer.cpp
+        src/editor/DragDropSystem.cpp
     )
     target_link_libraries(doppio PRIVATE caffeine-core ImGui)
     target_include_directories(doppio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/editor/DragDropSystem.cpp
+++ b/src/editor/DragDropSystem.cpp
@@ -1,0 +1,4 @@
+#include "editor/DragDropSystem.hpp"
+
+// DragDropManager is entirely inline in the header.
+// This file exists for future non-inline extensions.

--- a/src/editor/DragDropSystem.hpp
+++ b/src/editor/DragDropSystem.hpp
@@ -1,0 +1,97 @@
+#pragma once
+#include "core/Types.hpp"
+#include "assets/AssetTypes.hpp"
+#include <string>
+#include <filesystem>
+
+#ifdef CF_HAS_IMGUI
+#include <imgui.h>
+#endif
+
+namespace Caffeine::Editor {
+using namespace Caffeine;
+
+// ── Payload type identifiers ────────────────────────────────────
+
+constexpr const char* kPayloadAssetPath  = "ASSET_PATH";
+constexpr const char* kPayloadEntityDrag = "ENTITY_DRAG";
+
+// ── Drag-drop payload data ──────────────────────────────────────
+
+/// Carries an asset filesystem path + type through a drag-drop operation.
+struct AssetDropPayload {
+    char  path[512];
+    AssetType type;
+};
+
+// ── DragDropManager ─────────────────────────────────────────────
+
+/// Static helpers for ImGui drag-source and drop-target operations.
+/// Wraps ImGui's payload API with Caffeine-specific payload types.
+class DragDropManager {
+public:
+    /// Begin an asset drag-source. Returns true if the source is active.
+    static bool SourceAsset(const char* path, AssetType type, const char* label) {
+#ifdef CF_HAS_IMGUI
+        if (!ImGui::BeginDragDropSource()) return false;
+        AssetDropPayload payload;
+        strncpy(payload.path, path, sizeof(payload.path) - 1);
+        payload.path[sizeof(payload.path) - 1] = '\0';
+        payload.type = type;
+        ImGui::SetDragDropPayload(kPayloadAssetPath, &payload, sizeof(payload));
+        ImGui::Text("%s", label);
+        ImGui::EndDragDropSource();
+        return true;
+#else
+        (void)path; (void)type; (void)label;
+        return false;
+#endif
+    }
+
+    /// Begin an entity drag-source. Returns true if the source is active.
+    static bool SourceEntity(u32 entityId, const char* label) {
+#ifdef CF_HAS_IMGUI
+        if (!ImGui::BeginDragDropSource()) return false;
+        ImGui::SetDragDropPayload(kPayloadEntityDrag, &entityId, sizeof(u32));
+        ImGui::Text("%s", label);
+        ImGui::EndDragDropSource();
+        return true;
+#else
+        (void)entityId; (void)label;
+        return false;
+#endif
+    }
+
+    /// Accept an asset drop on the current item. Returns a pointer to the
+    /// payload data if dropped, or nullptr. The payload is valid only during
+    /// the current frame.
+    static const AssetDropPayload* AcceptAssetDrop() {
+#ifdef CF_HAS_IMGUI
+        if (!ImGui::BeginDragDropTarget()) return nullptr;
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(kPayloadAssetPath)) {
+            const auto* result = static_cast<const AssetDropPayload*>(payload->Data);
+            ImGui::EndDragDropTarget();
+            return result;
+        }
+        ImGui::EndDragDropTarget();
+#endif
+        return nullptr;
+    }
+
+    /// Accept an entity drop on the current item. Returns the entity ID, or
+    /// u32_max if no drop occurred.
+    static u32 AcceptEntityDrop() {
+#ifdef CF_HAS_IMGUI
+        if (!ImGui::BeginDragDropTarget()) return u32_max;
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(kPayloadEntityDrag)) {
+            u32 eid = *static_cast<const u32*>(payload->Data);
+            ImGui::EndDragDropTarget();
+            return eid;
+        }
+        ImGui::EndDragDropTarget();
+#endif
+        return u32_max;
+    }
+};
+
+} // namespace Caffeine::Editor

--- a/src/editor/InspectorPanel.cpp
+++ b/src/editor/InspectorPanel.cpp
@@ -1,4 +1,6 @@
 #include "editor/InspectorPanel.hpp"
+#include "editor/DragDropSystem.hpp"
+#include <filesystem>
 
 #ifdef CF_HAS_IMGUI
 
@@ -152,6 +154,14 @@ void InspectorPanel::drawSprite(ECS::World& world, ECS::Entity e, EditorContext&
         if (ImGui::InputText("Texture", buf, sizeof(buf))) {
             sprite->name = buf;
             ctx.isDirty = true;
+        }
+        // ── Drop target for texture assets ──
+        if (const auto* asset = DragDropManager::AcceptAssetDrop()) {
+            if (asset->type == AssetType::Texture) {
+                std::filesystem::path assetPath(asset->path);
+                sprite->name = assetPath.filename().string();
+                ctx.isDirty = true;
+            }
         }
         int frame = static_cast<int>(sprite->frameIndex);
         if (ImGui::DragInt("Frame", &frame, 1, 0, 1000)) {

--- a/src/editor/SceneViewport.cpp
+++ b/src/editor/SceneViewport.cpp
@@ -1,4 +1,7 @@
 #include "editor/SceneViewport.hpp"
+#include "editor/DragDropSystem.hpp"
+#include "editor/EditorContext.hpp"
+#include <filesystem>
 
 #ifdef CF_HAS_IMGUI
 
@@ -58,6 +61,32 @@ void SceneViewport::render(ECS::World& world, EditorContext& ctx
     if (viewportSize.x < 1 || viewportSize.y < 1) return;
     ImGui::Dummy(viewportSize);
 #endif
+
+    // ── Drag-drop target for assets ──
+    if (const auto* asset = DragDropManager::AcceptAssetDrop()) {
+        ctx.beginUndo(EditorCommand::AddEntity, u32_max, world);
+
+        ECS::Entity entity = world.create();
+        std::filesystem::path assetPath(asset->path);
+        setEntityName(world, entity, assetPath.stem().string().c_str());
+
+        // Convert mouse position to world coordinates
+        ImVec2 mousePos  = ImGui::GetMousePos();
+        ImVec2 viewportTL = ImGui::GetItemRectMin();
+        f32 localX = (mousePos.x - viewportTL.x) - viewportSize.x * 0.5f;
+        f32 localY = (mousePos.y - viewportTL.y) - viewportSize.y * 0.5f;
+        f32 scale  = ctx.viewportZoom * 50.0f;
+        f32 worldX = (localX - ctx.viewportPanX) / scale;
+        f32 worldY = (localY - ctx.viewportPanY) / scale;
+        world.add<ECS::Position2D>(entity, worldX, -worldY);
+
+        if (asset->type == AssetType::Texture) {
+            world.add<ECS::Sprite>(entity, assetPath.filename().string(), 0);
+        }
+
+        ctx.selectedEntity = entity;
+        ctx.endUndo(world);
+    }
 
     bool hovered = ImGui::IsItemHovered();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CAFFEINE_TEST_SOURCES
     test_pipeline.cpp
     test_editor.cpp
     ../src/editor/SceneSerializer.cpp
+    ../src/editor/DragDropSystem.cpp
 )
 
 if(SDL3_FOUND)

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -15,6 +15,7 @@
 #include "../src/editor/InspectorPanel.hpp"
 #include "../src/editor/SceneEditor.hpp"
 #include "../src/editor/SceneSerializer.hpp"
+#include "../src/editor/DragDropSystem.hpp"
 
 using namespace Caffeine;
 using namespace Caffeine::Editor;
@@ -596,4 +597,38 @@ TEST_CASE("SceneSerializer - deserialize from non-existent file", "[editor][seri
     ECS::World world;
     Editor::SceneSerializer serializer(world);
     REQUIRE(serializer.deserialize("_non_existent_file.caf") == false);
+}
+
+// ============================================================================
+// DragDropSystem Tests
+// ============================================================================
+
+TEST_CASE("DragDropSystem - payload constants are defined", "[editor][dragdrop]") {
+    REQUIRE(kPayloadAssetPath != nullptr);
+    REQUIRE(kPayloadEntityDrag != nullptr);
+    REQUIRE(std::strlen(kPayloadAssetPath) > 0);
+    REQUIRE(std::strlen(kPayloadEntityDrag) > 0);
+    REQUIRE(std::string(kPayloadAssetPath) != std::string(kPayloadEntityDrag));
+}
+
+TEST_CASE("DragDropSystem - AssetDropPayload size", "[editor][dragdrop]") {
+    REQUIRE(sizeof(AssetDropPayload) >= 512 + sizeof(AssetType));
+    REQUIRE(offsetof(AssetDropPayload, type) < sizeof(AssetDropPayload));
+}
+
+TEST_CASE("DragDropSystem - DragDropManager constants", "[editor][dragdrop]") {
+    // Verify that the static methods exist and compile (they are no-ops without ImGui)
+    // These test the API surface compiles correctly
+    const char* testPath = "test.png";
+    AssetType testType = AssetType::Texture;
+
+    // Source methods return false without ImGui context
+    bool sourceResult = DragDropManager::SourceAsset(testPath, testType, "test");
+    REQUIRE(sourceResult == false);
+
+    u32 entityResult = DragDropManager::AcceptEntityDrop();
+    REQUIRE(entityResult == u32_max);
+
+    const auto* assetResult = DragDropManager::AcceptAssetDrop();
+    REQUIRE(assetResult == nullptr);
 }


### PR DESCRIPTION
## Summary

Implement the Drag-and-Drop system (Issue #91, M2 milestone) with:

- **DragDropSystem.hpp/.cpp** — Unified payload types (`AssetDropPayload` struct, `ASSET_PATH`/`ENTITY_DRAG` constants) and `DragDropManager` static helper class (`SourceAsset`, `SourceEntity`, `AcceptAssetDrop`, `AcceptEntityDrop`)
- **SceneViewport drop target** — Accepts `ASSET_PATH` drops from AssetBrowser, creates entities at mouse position with `Position2D` and optional `Sprite` component (undo-wrapped)
- **InspectorPanel drop target** — Accepts `ASSET_PATH` drops (textures only) onto the Sprite name field, updates via `filesystem::path::filename()`
- **3 test cases** — Payload constants verification, struct size check, static API compilation test (602/603 passing, pre-existing compiler test failure)

## Changes

- `src/editor/DragDropSystem.hpp` — New (97 lines)
- `src/editor/DragDropSystem.cpp` — New (4 lines)
- `src/editor/SceneViewport.cpp` — +29 lines drop target
- `src/editor/InspectorPanel.cpp` — +10 lines drop target
- `CMakeLists.txt` — +1 line doppio source
- `tests/CMakeLists.txt` — +1 line test source
- `tests/test_editor.cpp` — +35 lines, 3 test cases

## Notes

- AssetBrowser source (`"ASSET_PATH"`) already existed — no changes needed
- HierarchyPanel source/target (`"ENTITY_DRAG"`) already existed — no changes needed
- All inline code guarded with `#ifdef CF_HAS_IMGUI`
- Closes #91