### PR TITLE
feat(assets): implement HotReloader for .caf asset hot-reloading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(caffeine-core
     src/assets/AssetManager.cpp
     src/assets/AssetPipeline.cpp
     src/assets/TextureCompiler.cpp
+    src/assets/HotReloader.cpp
     src/editor/TransformGizmo.cpp
     src/core/DebugHookRegistry.cpp
     src/editor/EditorContext.cpp

--- a/docs/plans/2026-05-15-hot-reload-design.md
+++ b/docs/plans/2026-05-15-hot-reload-design.md
@@ -1,0 +1,113 @@
+# Hot-Reload de Assets — Design
+
+**Date:** 2026-05-15
+**Issue:** #93
+**Milestone:** M2 — Visual Editing & Assets
+**Namespace:** `Caffeine::Assets`
+
+## Overview
+
+Monitoramento em background do diretório `assets/processed/` para detectar alterações em arquivos `.caf` recém-compilados pelo Asset Pipeline e acionar recargas in-place no `AssetManager` — sem reiniciar a engine ou perder o estado da cena no editor.
+
+## Arquitetura
+
+```
+[ assets/processed/*.caf ]  ←── AssetPipeline escreve .caf atualizado
+       │
+       ▼
+  HotReloader (background thread)
+       │  poll a cada 500ms
+       │  debounce 100ms (configurável)
+       │
+       ├── detecta timestamp change
+       ├── aguarda estabilidade (debounce)
+       └── enfileira path em m_PendingReloads (mutex)
+       │
+       ▼
+  HotReloader::Update()  ←── chamado na main thread (ex: EditorContext::Update)
+       │
+       ├── desenfileira batch sob mutex
+       ├── AssetManager::reloadAsset(path)
+       │     ├── reseta LinearAllocator + resolved data
+       │     ├── loadInternal(id) — fopen, BlobLoader, resolveEntry
+       │     └── retorna assetId
+       ├── determina tipo via getResolved<T>()
+       └── NotificationCallback(assetInfo) — editor toast
+```
+
+## Componentes
+
+### `HotReloader` (class)
+
+| Método | Descrição |
+|--------|-----------|
+| `Start(manager, processedDir, debounceMs)` | Inicia thread de polling |
+| `Stop()` | Join thread, limpa estado |
+| `Update()` | Processa fila de reloads na main thread |
+| `SetNotificationCallback(cb)` | Hook para notificação visual (editor toast) |
+| `IsRunning()` | Estado atual |
+
+### `HotReloadedAsset` (struct)
+
+| Campo | Tipo | Descrição |
+|-------|------|-----------|
+| `assetId` | `u32` | ID do asset recarregado |
+| `name` | `std::string` | Nome do arquivo sem extensão |
+| `type` | `AssetType` | Texture / Audio / Shader |
+
+### `AssetManager::reloadAsset(path)`
+
+Método público adicionado para trigger externo de reload:
+
+1. Busca `path` em `m_pathIndex` (com `m_basePath` prefixado)
+2. Reseta: `allocator.reset()`, `header/metadata/payload = nullptr`, `resolved = {}`
+3. Subtrai `sizeBytes` de `m_cachedBytes`
+4. Status → `Unloaded`
+5. Libera mutex
+6. `loadInternal(id)` — recarrega do disco, re-resolve
+7. Retorna `assetId` (ou `~0u` se não encontrado)
+
+## Threading
+
+- **Poll thread** (criada em `Start()`):
+  - Itera `directory_iterator` no diretório processado a cada 500ms
+  - Compara `last_write_time` com snapshot anterior
+  - Máquina de estados 3-state: *unmodified → debouncing → ready*
+  - Escreve em `m_PendingReloads` sob `m_Mutex`
+- **Main thread** (via `Update()`):
+  - Lê `m_PendingReloads` sob `m_Mutex`, troca com vetor vazio
+  - Executa reload fora do lock
+  - Dispara callback de notificação
+
+## Debounce
+
+Três estados por arquivo monitorado:
+
+1. **Unmodified** (`debounceStart == -1`): timestamp estável entre polls
+2. **First change detected** (`debounceStart >= 0`): timestamp mudou, timer inicia
+3. **Debounce elapsed** (`>= debounceMs` sem novas mudanças): reload é enfileirado
+
+## Testes
+
+5 testes em `tests/test_assetmanager.cpp`:
+
+| Teste | O que verifica |
+|-------|---------------|
+| `default state is not running` | `IsRunning() == false` sem `Start()` |
+| `Start/Stop lifecycle` | Transições de estado, idempotência de `Stop()` |
+| `Start twice does not crash` | `Start()` → `Start()` → `Stop()` |
+| `Update is safe when not running` | `Update()` antes de `Start()` e após `Stop()` |
+| `integration reload and callback` | Poll descobre mudança, `Update()` recarrega, callback dispara |
+
+## Uso no Editor
+
+```cpp
+// Inicialização
+m_HotReloader.Start(&m_AssetManager, "assets/processed/", 100);
+m_HotReloader.SetNotificationCallback([](const HotReloadedAsset& a) {
+    EditorToast::Show(ICON_FA_SYNC " {} recarregado", a.name);
+});
+
+// A cada frame (main thread)
+m_HotReloader.Update();
+```

--- a/src/Caffeine.hpp
+++ b/src/Caffeine.hpp
@@ -48,6 +48,7 @@
 #include "assets/AssetHandle.hpp"
 #include "assets/AssetManager.hpp"
 #include "assets/AssetPipeline.hpp"
+#include "assets/HotReloader.hpp"
 
 // Render
 #include "render/Camera2D.hpp"

--- a/src/assets/AssetManager.cpp
+++ b/src/assets/AssetManager.cpp
@@ -240,6 +240,33 @@ LoadStatus AssetManager::getStatus(u32 id) const {
     return m_assets[id]->status.load(std::memory_order_acquire);
 }
 
+u32 AssetManager::reloadAsset(const char* path) {
+    if (!path) return ~0u;
+
+    std::string key = m_basePath + path;
+    u32 id = ~0u;
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_pathIndex.find(key);
+        if (it == m_pathIndex.end()) return ~0u;
+        id = it->second;
+
+        auto& e = *m_assets[id];
+        m_cachedBytes.fetch_sub(e.sizeBytes, std::memory_order_relaxed);
+        e.allocator.reset();
+        e.header    = nullptr;
+        e.metadata  = nullptr;
+        e.payload   = nullptr;
+        e.resolved  = {};
+        e.sizeBytes = 0;
+        e.status.store(LoadStatus::Unloaded, std::memory_order_release);
+    }
+
+    loadInternal(id);
+    return id;
+}
+
 #ifdef CF_DEBUG
 u64 AssetManager::getFileWriteTime(const std::string& path) {
     std::error_code ec;

--- a/src/assets/AssetManager.hpp
+++ b/src/assets/AssetManager.hpp
@@ -46,6 +46,10 @@ public:
     CacheStats cacheStats() const;
     void       tick(u64 frameIndex = 0);
 
+    // Reload an already-loaded asset from disk by its loaded .caf path.
+    // Returns the asset ID, or ~0u if not found. Thread-safe.
+    u32        reloadAsset(const char* path);
+
     void       incRef(u32 id);
     void       decRef(u32 id);
     LoadStatus getStatus(u32 id) const;

--- a/src/assets/HotReloader.cpp
+++ b/src/assets/HotReloader.cpp
@@ -1,0 +1,189 @@
+#include "assets/HotReloader.hpp"
+#include "assets/AssetManager.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+namespace Caffeine::Assets {
+
+HotReloader::~HotReloader() { Stop(); }
+
+void HotReloader::Start(AssetManager* manager,
+                         const std::filesystem::path& processedDir,
+                         u32 debounceMs) {
+    Stop();
+
+    m_Manager      = manager;
+    m_ProcessedDir = std::filesystem::absolute(processedDir);
+    m_DebounceMs   = debounceMs;
+    m_StopRequested.store(false, std::memory_order_release);
+    m_Running.store(true, std::memory_order_release);
+
+    m_Thread = std::thread(&HotReloader::PollThreadMain, this);
+}
+
+void HotReloader::Stop() {
+    if (!m_Running.load(std::memory_order_acquire)) return;
+
+    m_StopRequested.store(true, std::memory_order_release);
+    if (m_Thread.joinable()) {
+        m_Thread.join();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        m_Files.clear();
+        m_PendingReloads.clear();
+    }
+
+    m_Running.store(false, std::memory_order_release);
+    m_Manager = nullptr;
+}
+
+void HotReloader::Update() {
+    std::vector<std::string> batch;
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        batch.swap(m_PendingReloads);
+    }
+
+    for (const auto& cafPath : batch) {
+        ReloadOne(cafPath);
+    }
+}
+
+// ── Private ──────────────────────────────────────────────────────────────────
+
+void HotReloader::ReloadOne(const std::string& cafPath) {
+    if (!m_Manager) return;
+
+    // AssetManager expects paths relative to its base path; the cafPath is
+    // the full absolute path.  We pass it through verbosely — reloadAsset()
+    // will match it inside m_pathIndex (the key stored there is the full
+    // path built from basePath + relative part supplied at loadAsync/Sync
+    // time).
+    u32 assetId = m_Manager->reloadAsset(cafPath.c_str());
+    if (assetId == ~0u) return;
+
+    auto status = m_Manager->getStatus(assetId);
+    if (status != LoadStatus::Loaded) return;
+
+    auto* tex = m_Manager->getResolved<Texture>(assetId);
+
+    HotReloadedAsset info;
+    info.assetId = assetId;
+    info.name    = std::filesystem::path(cafPath).stem().string();
+
+    // Try to determine type from the loaded header.  We query the resolved
+    // data as a proxy — if getResolved<Texture> returns non-null we know the
+    // type.  This is a lightweight heuristic for the notification only.
+    if (tex) {
+        info.type = AssetType::Texture;
+    } else if (m_Manager->getResolved<AudioClip>(assetId)) {
+        info.type = AssetType::Audio;
+    } else if (m_Manager->getResolved<ShaderBlob>(assetId)) {
+        info.type = AssetType::Shader;
+    }
+
+    if (m_NotificationCallback) {
+        m_NotificationCallback(info);
+    }
+}
+
+void HotReloader::PollThreadMain() {
+    using Clock = std::chrono::steady_clock;
+
+    while (!m_StopRequested.load(std::memory_order_acquire)) {
+        std::error_code ec;
+
+        // ── 1. Scan the processed directory ────────────────────────
+        std::vector<FileEntry> currentFiles;
+        for (const auto& entry :
+             std::filesystem::directory_iterator(m_ProcessedDir, ec)) {
+            if (!entry.is_regular_file()) continue;
+            if (entry.path().extension() != ".caf") continue;
+
+            auto ftime = entry.last_write_time(ec);
+            if (ec) continue;
+
+            FileEntry fe;
+            fe.path          = entry.path().string();
+            fe.lastWriteTime = static_cast<u64>(ftime.time_since_epoch().count());
+            currentFiles.push_back(std::move(fe));
+        }
+        if (ec) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            continue;
+        }
+
+        // ── 2. Compare with the previous snapshot ──────────────────
+        auto now = Clock::now();
+        i64 nowNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        now.time_since_epoch())
+                        .count();
+
+        std::lock_guard<std::mutex> lock(m_Mutex);
+
+        for (const auto& cur : currentFiles) {
+            auto prevIt = std::find_if(m_Files.begin(), m_Files.end(),
+                [&](const FileEntry& f) { return f.path == cur.path; });
+
+            if (prevIt == m_Files.end()) {
+                // Brand-new file — track it but don't reload yet.
+                FileEntry fe = cur;
+                fe.debounceStart = -1;
+                m_Files.push_back(std::move(fe));
+                continue;
+            }
+
+            if (prevIt->lastWriteTime == cur.lastWriteTime) {
+                if (prevIt->debounceStart >= 0) {
+                    i64 elapsedUs = (nowNs - prevIt->debounceStart) / 1000;
+                    if (static_cast<u64>(elapsedUs) >= static_cast<u64>(m_DebounceMs) * 1000) {
+                        prevIt->debounceStart = -1;
+                        if (std::find(m_PendingReloads.begin(),
+                                      m_PendingReloads.end(),
+                                      cur.path) == m_PendingReloads.end()) {
+                            m_PendingReloads.push_back(cur.path);
+                        }
+                    }
+                }
+                continue;
+            }
+
+            // Timestamp differs → (re)start debounce.
+            if (prevIt->debounceStart < 0) {
+                prevIt->debounceStart = nowNs;
+                prevIt->lastWriteTime = cur.lastWriteTime;
+                continue;
+            }
+
+            // Debounce already running — check if enough time elapsed.
+            i64 elapsedUs = (nowNs - prevIt->debounceStart) / 1000;
+            if (static_cast<u64>(elapsedUs) >= static_cast<u64>(m_DebounceMs) * 1000) {
+                // Stable change — queue for reload.
+                prevIt->lastWriteTime = cur.lastWriteTime;
+                prevIt->debounceStart = -1;
+
+                if (std::find(m_PendingReloads.begin(),
+                              m_PendingReloads.end(),
+                              cur.path) == m_PendingReloads.end()) {
+                    m_PendingReloads.push_back(cur.path);
+                }
+            }
+        }
+
+        m_Files.erase(
+            std::remove_if(m_Files.begin(), m_Files.end(),
+                [&](const FileEntry& f) {
+                    return std::none_of(currentFiles.begin(), currentFiles.end(),
+                        [&](const FileEntry& c) { return c.path == f.path; });
+                }),
+            m_Files.end());
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+}
+
+} // namespace Caffeine::Assets

--- a/src/assets/HotReloader.hpp
+++ b/src/assets/HotReloader.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "core/Types.hpp"
+#include "assets/AssetTypes.hpp"
+
+#include <atomic>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace Caffeine::Assets {
+
+class AssetManager;
+
+// ============================================================================
+struct HotReloadedAsset {
+    u32         assetId = ~0u;
+    std::string name;
+    AssetType   type = AssetType::Unknown;
+};
+
+// ============================================================================
+// @brief  Monitors processado .caf directory for changes and triggers
+//         in-place reloads in AssetManager via a background poll thread.
+//
+//  Flow:
+//    1. Background thread scans processado/ for .caf file timestamp changes.
+//    2. After a debounce delay the timestamp remains different, the file
+//       path is queued for reload.
+//    3. Update() (called from the main thread) pops the queue, calls
+//       AssetManager::reloadAsset(), then fires the optional notification
+//       callback (used by the editor for toast messages).
+//
+//  Threading:
+//    - Poll thread writes to m_PendingReloads (under mutex).
+//    - Update() reads from m_PendingReloads (under mutex), does the actual
+//      reload, then fires the notification on the caller's thread.
+// ============================================================================
+class HotReloader {
+public:
+    using NotificationCallback = std::function<void(const HotReloadedAsset&)>;
+
+    HotReloader() = default;
+    ~HotReloader();
+
+    HotReloader(const HotReloader&) = delete;
+    HotReloader& operator=(const HotReloader&) = delete;
+
+    // Start the background poll thread.
+    //  manager      — AssetManager whose loaded assets should be reloaded.
+    //  processedDir — path to the directory containing .caf files (normally
+    //                 projectRoot/assets/processado from AssetPipeline).
+    //  debounceMs   — minimum time (ms) to wait after the last file write
+    //                 before triggering a reload (default 100).
+    void Start(AssetManager* manager,
+               const std::filesystem::path& processedDir,
+               u32 debounceMs = 100);
+
+    void Stop();
+
+    // Must be called from the main thread each frame.
+    void Update();
+
+    void SetNotificationCallback(NotificationCallback cb) {
+        m_NotificationCallback = std::move(cb);
+    }
+
+    bool IsRunning() const { return m_Running; }
+
+private:
+    struct FileEntry {
+        std::string path;
+        u64 lastWriteTime  = 0;
+        i64 debounceStart  = -1;  // steady_clock time when change was first seen
+    };
+
+    void PollThreadMain();
+    void ReloadOne(const std::string& cafPath);
+
+    AssetManager* m_Manager = nullptr;
+    std::filesystem::path m_ProcessedDir;
+    u32 m_DebounceMs = 100;
+
+    std::vector<FileEntry> m_Files;
+    std::mutex             m_Mutex;
+    std::vector<std::string> m_PendingReloads;
+
+    std::thread             m_Thread;
+    std::atomic<bool>       m_StopRequested{false};
+    std::atomic<bool>       m_Running{false};
+
+    NotificationCallback m_NotificationCallback;
+};
+
+} // namespace Caffeine::Assets

--- a/tests/test_assetmanager.cpp
+++ b/tests/test_assetmanager.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "../src/assets/AssetManager.hpp"
+#include "../src/assets/HotReloader.hpp"
 #include "../src/core/io/CafWriter.hpp"
 #include "../src/core/io/CafTypes.hpp"
 
@@ -238,4 +239,113 @@ TEST_CASE("AssetManager - tick advances frame index", "[assets]") {
     mgr.tick(42);
     CacheStats s = mgr.cacheStats();
     REQUIRE(s.totalCachedBytes == 0);
+}
+
+// ============================================================================
+// HotReloader tests
+// ============================================================================
+
+TEST_CASE("HotReloader - default state is not running", "[hotreload]") {
+    HotReloader hr;
+    REQUIRE_FALSE(hr.IsRunning());
+}
+
+TEST_CASE("HotReloader - Start/Stop lifecycle", "[hotreload]") {
+    auto tmpDir = std::filesystem::temp_directory_path() / "caffeine_hr_start_stop";
+    std::filesystem::create_directories(tmpDir);
+
+    HotReloader hr;
+    REQUIRE_FALSE(hr.IsRunning());
+    hr.Start(nullptr, tmpDir, 10);
+    REQUIRE(hr.IsRunning());
+    hr.Stop();
+    REQUIRE_FALSE(hr.IsRunning());
+    hr.Stop();
+    REQUIRE_FALSE(hr.IsRunning());
+
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST_CASE("HotReloader - Start twice does not crash", "[hotreload]") {
+    auto tmpDir = std::filesystem::temp_directory_path() / "caffeine_hr_start_twice";
+    std::filesystem::create_directories(tmpDir);
+
+    HotReloader hr;
+    hr.Start(nullptr, tmpDir, 10);
+    REQUIRE(hr.IsRunning());
+    hr.Start(nullptr, tmpDir, 10);
+    REQUIRE(hr.IsRunning());
+    hr.Stop();
+    REQUIRE_FALSE(hr.IsRunning());
+
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST_CASE("HotReloader - Update is safe when not running", "[hotreload]") {
+    HotReloader hr;
+    hr.Update();
+
+    auto tmpDir = std::filesystem::temp_directory_path() / "caffeine_hr_update_safe";
+    std::filesystem::create_directories(tmpDir);
+    hr.Start(nullptr, tmpDir);
+    hr.Stop();
+    hr.Update();
+    REQUIRE_FALSE(hr.IsRunning());
+
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST_CASE("HotReloader - integration reload and callback", "[hotreload]") {
+    auto tmpDir = std::filesystem::temp_directory_path() / "caffeine_hr_reload";
+    std::filesystem::remove_all(tmpDir);
+    std::filesystem::create_directories(tmpDir);
+    auto cafPath = tmpDir / "test_reload.caf";
+
+    {
+        TextureMetadata meta{};
+        meta.width = 2; meta.height = 2; meta.format = 0; meta.mipLevels = 1;
+        u8 pixels[16];
+        std::memset(pixels, 0xAB, sizeof(pixels));
+        CafWriter::write(cafPath.string().c_str(), AssetType::Texture,
+                         CAF_FLAG_NONE, &meta, sizeof(meta), pixels, sizeof(pixels));
+    }
+
+    AssetManager mgr(nullptr, "");
+    auto handle = mgr.loadSync<Texture>(cafPath.string().c_str());
+    REQUIRE(handle.isReady());
+    REQUIRE(handle.get()->pixels[0] == 0xAB);
+
+    bool callbackFired = false;
+    Caffeine::Assets::HotReloadedAsset callbackInfo;
+    {
+        HotReloader hr;
+        hr.SetNotificationCallback([&](const Caffeine::Assets::HotReloadedAsset& a) {
+            callbackFired = true;
+            callbackInfo  = a;
+        });
+        hr.Start(&mgr, tmpDir, 10);
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(600));
+
+        {
+            TextureMetadata meta{};
+            meta.width = 2; meta.height = 2; meta.format = 0; meta.mipLevels = 1;
+            u8 pixels[16];
+            std::memset(pixels, 0xCD, sizeof(pixels));
+            CafWriter::write(cafPath.string().c_str(), AssetType::Texture,
+                             CAF_FLAG_NONE, &meta, sizeof(meta), pixels, sizeof(pixels));
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+        hr.Update();
+
+        REQUIRE(handle.get()->pixels[0] == 0xCD);
+        REQUIRE(callbackFired);
+        REQUIRE(callbackInfo.assetId == handle.id());
+        REQUIRE(callbackInfo.type    == AssetType::Texture);
+
+        hr.Stop();
+    }
+
+    std::filesystem::remove_all(tmpDir);
 }


### PR DESCRIPTION
## Summary

Implements **Hot-Reload de Assets** (#93, Milestone M2) — a `HotReloader` class that monitors processed `.caf` file changes and triggers in-place reloads in `AssetManager`, with debounce, background polling thread, and editor toast notification callback support.

### Changes

- **`HotReloader.hpp/cpp`** — New class with:
  - Background poll thread (500ms interval) scanning processed dir for `.caf` changes
  - Configurable debounce (default 100ms) with 3-state machine (unmodified → debouncing → ready)
  - Thread-safe pending reload queue (mutex-protected)
  - `Update()` must be called from main thread to drain queue and execute reloads
  - `NotificationCallback` for editor toast integration
  - RAII destructor joins thread automatically

- **`AssetManager`** — Added `reloadAsset(const char* path)` public method:
  - Finds asset by path in `m_pathIndex` (with `m_basePath` prefix)
  - Resets allocator, clears resolved data, sets status to Unloaded
  - Re-runs `loadInternal(id)` — full reload from disk
  - Returns asset ID or `~0u` if not found

- **Build/tests** — Registered in CMakeLists.txt, included in Caffeine.hpp, 5 unit tests

### Bugs fixed during implementation

1. **Debounce logic bug**: When file was unchanged between poll cycles, debounce was unconditionally reset (`debounceStart = -1`), making reloads never trigger on single writes. Fixed by checking elapsed time in the "no change" branch.

2. **Path separator mismatch**: `generic_string()` produced `/` on Windows but AssetManager uses native `\` separators. Changed to `string()`.

### Test Results

```
All tests passed (15 assertions in 5 test cases)
Full suite: 616 tests, 615 passed (1 pre-existing failure only)
```

### Design Doc

`docs/plans/2026-05-15-hot-reload-design.md`