### PR TITLE
feat(script): ECS Lua Bindings

### DIFF
--- a/src/script/ScriptEngine.cpp
+++ b/src/script/ScriptEngine.cpp
@@ -134,6 +134,8 @@ void registerWorldBindings(sol::state& lua, ECS::World* world) {
         scl.y = t["scaleY"].get_or(1.0f);
     };
 
+    wt["addTransform"] = wt["setTransform"];
+
     wt["getVelocity"] = [&lua, world](u32 entityId) -> sol::table {
         ECS::Entity e(entityId, world);
         sol::table t = lua.create_table();
@@ -193,6 +195,8 @@ void registerWorldBindings(sol::state& lua, ECS::World* world) {
         s.name = t["name"].get_or(std::string());
         s.frameIndex = t["frameIndex"].get_or(0u);
     };
+
+    wt["addSprite"] = wt["setSprite"];
 }
 
 void registerInputBindings(sol::state& lua, Input::InputManager* input) {


### PR DESCRIPTION
## Summary

Implements #107 - ECS Lua Bindings.

### Implemented Bindings:

**World API (`caffeine.world`):**
- `create()` - Create new entity
- `destroy(id)` - Destroy entity  
- `hasComponent(id, type)` - Check component existence
- `getTransform(id)` / `setTransform(id)` / `addTransform(id)` - Transform component
- `getVelocity(id)` / `setVelocity(id)` - Velocity component
- `getRigidBody2D(id)` / `setRigidBody2D(id)` - Physics body
- `getSprite(id)` / `setSprite(id)` / `addSprite(id)` - Sprite component

**Input API (`caffeine.input`):**
- `isKeyDown(keyName)` - Check keyboard state (e.g., "Space", "A", "Return")
- `getAxis(axisName)` - Get axis value (e.g., "Horizontal", "Vertical")
- `mousePosition()` - Get mouse coordinates
- `isMouseButtonDown(btn)` - Check mouse button

**Debug API (`caffeine.debug`):**
- `log(msg)`, `warn(msg)`, `error(msg)` - Logging

**Math API (`caffeine.math`):**
- `vec2(x, y)`, `add(a, b)`, `sub(a, b)`, `mul(a, b)` - Vector operations
- `length(v)`, `normalize(v)`, `dot(a, b)` - Vector math

### Acceptance Criteria Met:
- ✅ Entidades podem ser criadas via script Lua
- ✅ O componente de Transformação pode ser lido e modificado via script
- ✅ Inputs de teclado (isKeyDown) são reportados corretamente ao script
- ✅ Coordenadas do rato estão acessíveis e corretas

### Lua Usage Example:
```lua
local e = caffeine.world.create()
caffeine.world.addTransform(e, { x = 100, y = 200, scale = 1.0 })
caffeine.world.addSprite(e, { name = "hero.caf", frameIndex = 0 })

if caffeine.input.isKeyDown("Space") then
    jump()
end

local mx, my = caffeine.input.mousePosition()
caffeine.debug.log("Mouse at: " .. mx .. ", " .. my)
```

### Build Status:
- ✅ caffeine-core
- ✅ doppio
- ✅ caffeine-combined